### PR TITLE
Fix #1037

### DIFF
--- a/baseform.pas
+++ b/baseform.pas
@@ -52,11 +52,11 @@ implementation
 uses LCLType, ButtonPanel, VarGrid, ComCtrls, StdCtrls, ExtCtrls, lclversion;
 
 var
-  ScaleM, ScaleD: integer;
+  ScaleMultiplier, ScaleDivider: integer;
 
 function ScaleInt(i: integer): integer;
 begin
-  Result:=i*ScaleM div ScaleD;
+  Result:=i*ScaleMultiplier div ScaleDivider;
 end;
 
 type THackControl = class(TWinControl) end;
@@ -117,8 +117,8 @@ begin
     if C is TWinControl then
       TWinControl(C).DisableAlign;
     try
-      if ScaleM <> ScaleD then begin
-        ScaleConstraints(ScaleM, ScaleD);
+      if ScaleMultiplier <> ScaleDivider then begin
+        ScaleConstraints(ScaleMultiplier, ScaleDivider);
         R := BaseBounds;
         R.Left := ScaleInt(R.Left);
         R.Top := ScaleInt(R.Top);
@@ -237,26 +237,26 @@ var
   i: integer;
   tm: TLCLTextMetric;
 begin
-  if ScaleD <> 0 then exit;
-  ScaleD:=11;
+  if ScaleDivider <> 0 then exit;
+  ScaleDivider:=11;
   i:=Screen.SystemFont.Height;
   if i = 0 then begin
     if Canvas.GetTextMetrics(tm) then begin
-      ScaleM:=tm.Ascender;
-      if ScaleM < 11 then
-        ScaleM:=11;
+      ScaleMultiplier:=tm.Ascender;
+      if ScaleMultiplier < 11 then
+        ScaleMultiplier:=11;
     end
     else begin
-      ScaleM:=Canvas.TextHeight('Wy');
-      ScaleD:=13;
+      ScaleMultiplier:=Canvas.TextHeight('Wy');
+      ScaleDivider:=13;
     end;
-    if ScaleM = 0 then
-      ScaleM:=ScaleD;
+    if ScaleMultiplier = 0 then
+      ScaleMultiplier:=ScaleDivider;
   end
   else
-    ScaleM:=Abs(i);
-  ScaleM:=ScaleM*IntfScale;
-  ScaleD:=ScaleD*100;
+    ScaleMultiplier:=Abs(i);
+  ScaleMultiplier:=ScaleMultiplier*IntfScale;
+  ScaleDivider:=ScaleDivider*100;
 end;
 
 initialization

--- a/daemonoptions.pas
+++ b/daemonoptions.pas
@@ -24,7 +24,7 @@ unit DaemonOptions;
 interface
 
 uses
-  Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics, Dialogs, StdCtrls, ExtCtrls, Spin, ComCtrls, CheckLst, EditBtn, MaskEdit,
+  Classes, SysUtils, LazUTF8, LResources, Forms, Controls, Graphics, Dialogs, StdCtrls, ExtCtrls, Spin, ComCtrls, CheckLst, EditBtn, MaskEdit,
   ButtonPanel, BaseForm;
 
 resourcestring

--- a/restranslator.pas
+++ b/restranslator.pas
@@ -12,7 +12,7 @@ unit ResTranslator;
 interface
 
 uses
-  Classes, StrUtils, SysUtils, FileUtil, LResources, TypInfo, LCLProc, LazUTF8;
+  Classes, StrUtils, SysUtils, FileUtil, LazFileUtils, LResources, TypInfo, LCLProc, LazUTF8;
 
 type
 
@@ -243,7 +243,7 @@ procedure MakeTranslationFile(Language: AnsiString); overload;
 var
   lLang, sLang, s: string;
 begin
-  LCLGetLanguageIDs(lLang, sLang);
+  LazGetLanguageIDs(lLang, sLang);
   sLang:=AnsiLowerCase(sLang);
   s:=ExtractFileNameOnly(ParamStrUtf8(0));
   if (sLang <> '') and not FileExistsUTF8(DefaultLangDir + s + '.' + sLang) then
@@ -335,7 +335,7 @@ var
   lLang, sLang, s: string;
   i: integer;
 begin
-  LCLGetLanguageIDs(lLang, sLang);
+  LazGetLanguageIDs(lLang, sLang);
   lLang:=LowerCase(lLang);
   sLang:=LowerCase(sLang);
 {$ifdef windows}

--- a/utils.pas
+++ b/utils.pas
@@ -104,7 +104,7 @@ uses
 {$ifdef CALLSTACK}
   lineinfo2,
 {$endif CALLSTACK}
-  FileUtil, StdCtrls, Graphics;
+  FileUtil, LazUTF8, LazFileUtils, StdCtrls, Graphics;
 
 {$ifdef windows}
 function FileOpenUTF8(Const FileName : string; Mode : Integer) : THandle;
@@ -174,7 +174,7 @@ var
   s: widestring;
 begin
   if Win32Platform <> VER_PLATFORM_WIN32_NT then begin
-    Result:=FileUtil.ParamStrUTF8(Param);
+    Result:=LazUTF8.ParamStrUTF8(Param);
     exit;
   end;
 
@@ -239,7 +239,7 @@ end;
 
 function ParamStrUTF8(Param: Integer): utf8string;
 begin
-  Result:=FileUtil.ParamStrUTF8(Param);
+  Result:=LazUTF8.ParamStrUTF8(Param);
 end;
 
 function ParamCount: integer;


### PR DESCRIPTION
Added Lazarus 1.8 support
Fixed BaseForm.ScaleD variable name conflicted with Form.Scaled
Fixed usages of some FileUtil deprecated functions