### PR TITLE
Add "private" column

### DIFF
--- a/main.lfm
+++ b/main.lfm
@@ -310,6 +310,12 @@ inherited MainForm: TMainForm
           Title.Caption = 'Size left'
           Width = 0
           Visible = False
+        end      
+        item
+          Alignment = taRightJustify
+          Title.Caption = 'Private'
+          Width = 0
+          Visible = False
         end>
       FixedCols = 0
       Options = [goFixedVertLine, goFixedHorzLine, goColSizing, goColMoving, goRowSelect, goThumbTracking, goDblClickAutoSize, goHeaderHotTracking, goHeaderPushedLook]

--- a/main.pas
+++ b/main.pas
@@ -135,6 +135,9 @@ resourcestring
   sBiDiRightLeftNoAlign = 'Right->Left (No Align)';
   sBiDiRightLeftReadOnly = 'Right->Left (Reading Only)';
 
+  sPrivateOn = 'ON';
+  sPrivateOff = 'OFF';
+
 type
 
   // for torrent folder
@@ -815,6 +818,7 @@ const
   idxQueuePos = 21;
   idxSeedingTime = 22;
   idxSizeLeft = 23;
+  idxPrivate = 24;
 
   idxTag = -1;
   idxSeedsTotal = -2;
@@ -875,11 +879,11 @@ const
 
   StatusFiltersCount = 8;
 
-  TorrentFieldsMap: array[idxName..idxSizeLeft] of string =
+  TorrentFieldsMap: array[idxName..idxPrivate] of string =
     ('', 'totalSize', '', 'status', 'peersSendingToUs,seeders',
     'peersGettingFromUs,leechers', '', '', 'eta', 'uploadRatio',
     'downloadedEver', 'uploadedEver', '', '', 'addedDate', 'doneDate', 'activityDate', '', 'bandwidthPriority',
-    '', '', 'queuePosition', 'secondsSeeding', 'leftUntilDone');
+    '', '', 'queuePosition', 'secondsSeeding', 'leftUntilDone', 'isPrivate');
 
   FinishedQueue = 1000000;
 
@@ -4294,6 +4298,14 @@ begin
           else
             Text:='';
         end;
+      idxPrivate:
+        begin
+          j:=Sender.Items[idxPrivate, ARow];
+          if j >= 1 then
+            Text:=sPrivateOn
+          else
+            Text:=sPrivateOff;
+        end;
     end;
   end;
 end;
@@ -5639,6 +5651,7 @@ begin
     FieldExists[idxPriority]:=t.IndexOfName('bandwidthPriority') >= 0;
     FieldExists[idxQueuePos]:=t.IndexOfName('queuePosition') >= 0;
     FieldExists[idxSeedingTime]:=t.IndexOfName('secondsSeeding') >= 0;
+    FieldExists[idxPrivate]:=t.IndexOfName('isPrivate') >= 0;
   end;
 
   UpSpeed:=0;
@@ -5875,6 +5888,9 @@ begin
         Inc(j, FinishedQueue);
       FTorrents[idxQueuePos, row]:=j;
     end;
+
+    if FieldExists[idxPrivate] then
+      FTorrents[idxPrivate, row]:=t.Integers['isPrivate'];
 
     DownSpeed:=DownSpeed + FTorrents[idxDownSpeed, row];
     UpSpeed:=UpSpeed + FTorrents[idxUpSpeed, row];

--- a/rpc.pas
+++ b/rpc.pas
@@ -509,7 +509,7 @@ begin
                                     'maxConnectedPeers', 'nextAnnounceTime', 'dateCreated', 'creator', 'eta', 'peersSendingToUs',
                                     'seeders','peersGettingFromUs','leechers', 'uploadRatio', 'addedDate', 'doneDate',
                                     'activityDate', 'downloadLimited', 'uploadLimited', 'downloadDir', 'id', 'pieces',
-                                    'trackerStats', 'secondsDownloading', 'secondsSeeding', 'magnetLink']);
+                                    'trackerStats', 'secondsDownloading', 'secondsSeeding', 'magnetLink', 'isPrivate']);
   try
     if args <> nil then begin
       t:=args.Arrays['torrents'];


### PR DESCRIPTION
Add "private" column -- Reflects key-value pair "private=1" or "private=0" in the "info" dict of the torrent's metainfo file

Not tested for 5.14, It should work fine.
Fully tested for transmission cfp fork here -->https://github.com/cfpp2p/transmisson-remote-gui/commit/5721cfabbe487108dae604380d64c63e2d0a8857