### PR TITLE
Don't needlessly URL-encode the URL passed to the Unix URL opener

### DIFF
--- a/utils.pas
+++ b/utils.pas
@@ -421,10 +421,7 @@ begin
     end;
   end;
 
-  fn:=FileName;
-  if Pos('://', fn) > 0 then
-    fn:=StringReplace(fn, '#', '%23', [rfReplaceAll]);
-  Wrkprocess.Parameters.Add(fn);
+  Wrkprocess.Parameters.Add(FileName);
   WrkProcess.Executable:=cmd;
 
   try


### PR DESCRIPTION
This piece of code was added back in bb3ff239afdb096b784a82684b86dbcc45f25c6a , when the `CommandLine` property was used to spawn the xdg-/gnome-/kde-open process. Since a `#` might have been interpreted by the shell (which might have been used along the way by the underlying machinery to spawn the process) as a start of a comment, it was URL-encoded.
However, since the function now uses the `Parameters` array which is passed directly into the process that's going to be created, there is no need to do that. Plus, the function won't fail when trying to open a folder or file with `://` inside its path, should a sequence like this ever exist for whatever reasons.