### PR TITLE
Use 64-bit Cocoa instead of 32-bit Carbon for macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ matrix:
       deploy: *deploy
 
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.3
       stage: build
       env:
         - arch=osx

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ ifneq ($(findstring $(OS_TARGET),win32,win64),)
 LCL_WIDGETSET=win32
 endif
 ifneq ($(findstring $(OS_TARGET),darwin),)
-LCL_WIDGETSET=carbon
+LCL_WIDGETSET=cocoa
 endif
 ifeq ($(DEBUG),)
   COMP_OPT=-O3 -g- -CX -XX -Xs -Scgi -l -vewnhibq

--- a/Makefile.fpc
+++ b/Makefile.fpc
@@ -37,7 +37,7 @@ ifneq ($(findstring $(OS_TARGET),win32,win64),)
 LCL_WIDGETSET=win32
 endif
 ifneq ($(findstring $(OS_TARGET),darwin),)
-LCL_WIDGETSET=carbon
+LCL_WIDGETSET=cocoa
 endif
 
 ifeq ($(DEBUG),)

--- a/connoptions.pas
+++ b/connoptions.pas
@@ -219,12 +219,17 @@ begin
   edCertFile.Visible:=cbShowAdvanced.Checked;
   txCertPass.Visible:=cbShowAdvanced.Checked;
   edCertPass.Visible:=cbShowAdvanced.Checked;
+{$ifndef LCLCocoa}
 {$ifndef LCLgtk2}
   tabConnection.TabVisible:=cbShowAdvanced.Checked;
 {$endif LCLgtk2}
   tabProxy.TabVisible:=cbShowAdvanced.Checked;
   tabPaths.TabVisible:=cbShowAdvanced.Checked;
   tabMisc.TabVisible:=cbShowAdvanced.Checked;
+{$endif LCLCocoa}
+{$ifdef LCLCocoa}
+  Page.ShowTabs:=cbShowAdvanced.Checked;
+{$endif LCLCocoa}
   cbShowAdvanced.Visible:=not cbShowAdvanced.Checked;
   Page.ActivePage:=tabConnection;
 end;

--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -24,11 +24,11 @@ fi
 mkdir -p ../../Release/
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" ../../about.lfm
 
-lazbuild -B ../../transgui.lpi --lazarusdir=/Developer/lazarus/
+lazbuild -B ../../transgui.lpi --lazarusdir=/Developer/lazarus/ --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa
 
 # Building Intel version
-make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=i386 "$lazdir"
-make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=i386 "$lazdir"
+make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 "$lazdir"
+make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 "$lazdir"
 
 if ! [ -e $exename ]; then
   echo "$exename does not exist"
@@ -54,7 +54,7 @@ sed -e "s/@prog_ver@/$prog_ver/" Info.plist > "$appfolder/Contents/Info.plist"
 
 ln -s /Applications "$dmgfolder/Drag \"Transmission Remote GUI\" here!"
 
-hdiutil create -ov -anyowners -volname "transgui-v$prog_ver" -format UDRW -srcfolder ./Release "tmp.dmg"
+hdiutil create -ov -anyowners -volname "transgui-v$prog_ver" -format UDRW -srcfolder ./Release -fs HFS+ "tmp.dmg"
 
 mount_device="$(hdiutil attach -readwrite -noautoopen "tmp.dmg" | awk 'NR==1{print$1}')"
 mount_volume="$(mount | grep "$mount_device" | sed 's/^[^ ]* on //;s/ ([^)]*)$//')"

--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -3,9 +3,9 @@
 set -x
 set -e
 
-lazarus_ver="1.8.4"
-fpc="fpc-3.0.4.intel-macosx"
-lazarus="lazarus-1.8.4-i686-macosx"
+lazarus_ver="2.0.4"
+fpc="fpc-3.0.4a.intel-macosx"
+lazarus="lazarus-2.0.4-i686-macosx"
 
 if [ -n "${sourceforge_mirror-}" ]; then
   mirror_string="&use_mirror=${sourceforge_mirror}"
@@ -27,4 +27,5 @@ if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
   sudo installer -pkg "$pkgpath/lazarus.pkg" -target /
   hdiutil unmount "$pkgpath"
   rm "$lazarus.dmg"
+  lazbuild --build-ide= --compiler=fpc --cpu=x86_64 --widgetset=cocoa
 fi


### PR DESCRIPTION
I was able to compile a functional version of Transmission Remote GUI for macOS that uses Cocoa instead of Carbon and is 64-bit instead of 32-bit, which I have released on my fork. This is rather experimental and not well-tested, but I thought it might be a good idea to create a pull request now in order to raise awareness. Here be dragons!