### PR TITLE
Enable smart linking

### DIFF
--- a/transgui.lpi
+++ b/transgui.lpi
@@ -211,7 +211,7 @@
       <Verbosity>
         <ShowHints Value="False"/>
       </Verbosity>
-      <CustomOptions Value="-Sa"/>
+      <CustomOptions Value="-Sa -CX -XX"/>
       <ExecuteBefore>
         <ShowAllMessages Value="True"/>
       </ExecuteBefore>


### PR DESCRIPTION
This change is kind of necessary for the Cocoa build unless certain references to the macOS framework headers are removed from transgui. Otherwise, there is a dependency on Carbon that cannot be resolved in the x86_64 macOS world, causing problems during compilation. See https://wiki.freepascal.org/univint

These flags enable smart linking, which causes anything that isn't used to be dropped at compile-time. Importantly, that includes the Carbon dependency when compiling for Cocoa.

I don't know how to figure out exactly what would need to be removed to get rid of the Carbon dependency, so this was the easier solution. Since it affects the other builds, at the request of @PeterDaveHello, I have separated it into its own pull request. In theory, this shouldn't break anything, but it obviously requires testing.