### PR TITLE
Add WatchWindowOpen

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -2709,7 +2709,8 @@ begin
         AppNormal;
 
         ok:=not Ini.ReadBool('Interface', 'ShowAddTorrentWindow', True);
-        if FWatchDownloading then ok:= true;
+        openWindow := Ini.ReadBool('Interface', 'WatchWindowOpen', False)
+        if FWatchDownloading and openWindow then ok:= true;
         if ok then
           btSelectAllClick(nil)
         else begin

--- a/main.pas
+++ b/main.pas
@@ -2709,8 +2709,7 @@ begin
         AppNormal;
 
         ok:=not Ini.ReadBool('Interface', 'ShowAddTorrentWindow', True);
-        openWindow := Ini.ReadBool('Interface', 'WatchWindowOpen', False)
-        if FWatchDownloading and openWindow then ok:= true;
+        if FWatchDownloading and Ini.ReadBool('Interface', 'WatchWindowOpen', False) then ok:= true;
         if ok then
           btSelectAllClick(nil)
         else begin

--- a/readme.txt
+++ b/readme.txt
@@ -107,8 +107,8 @@ GlobalHotkeyMod={Modifier Key} [MOD_SHIFT , MOD_CONTROL , MOD_ALT , MOD_WIN alon
 [Interface]
 WatchLocalFolder= {LOCAL Folder to watch for torrent files}
 WatchDestinationFolder= {REMOTE destination where the data would be saved if missing or empty last destination folder is used}
-WatchInterval=1 {Time period in MINUTES between folder scans for torrents, may be fractional values 0,50 = 30 seconds}
-
+WatchInterval=1 {Time period in MINUTES between folder scans for torrents, may be fractional values 0,50/0.50 = 30 seconds}
+WatchWindowOpen={Set to True to open the application window when the watcher picks up a file}
 
 [Shortcuts]
 ;Modify all the shortcuts of the GUI here


### PR DESCRIPTION
Issue https://github.com/transmission-remote-gui/transgui/issues/1148 Asked for a way to ensure that the application window wouldn't open when the File Watcher added in https://github.com/transmission-remote-gui/transgui/issues/1070 picks up and adds a torrent. I don't have a _ton_ of Pascal experience but I believe it's because `btSelectAllClick` will open the application window