### PR TITLE
Openssl exception

### DIFF
--- a/StringToVK.pas
+++ b/StringToVK.pas
@@ -1,3 +1,33 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit StringToVK;
 
 {$mode objfpc}{$H+}

--- a/about.lfm
+++ b/about.lfm
@@ -884,6 +884,16 @@ inherited AboutForm: TAboutForm
           'consider it more useful to permit linking proprietary applications with the'
           'library.  If this is what you want to do, use the GNU Lesser General'
           'Public License instead of this License.'
+          ''
+          'In addition, as a special exception, OpenVPN Technologies, Inc. '
+          'gives permission to link the code of this program with the OpenSSL'
+          'Library (or with modified versions of OpenSSL that use the same'
+          'license as OpenSSL), and distribute linked combinations including'
+          'the two. You must obey the GNU General Public License in all'
+          'respects for all of the code used other than OpenSSL. If you modify'
+          'this file, you may extend this exception to your version of the file,'
+          'but you are not obligated to do so. If you do not wish to do so,'
+          'delete this exception statement from your version.'
         )
         ReadOnly = True
         ScrollBars = ssBoth

--- a/about.pas
+++ b/about.pas
@@ -15,6 +15,18 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
 *************************************************************************************}
 
 unit About;

--- a/addlink.pas
+++ b/addlink.pas
@@ -15,6 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+
 *************************************************************************************}
 
 unit AddLink;

--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -15,6 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+
 *************************************************************************************}
 
 unit AddTorrent;

--- a/addtracker.pas
+++ b/addtracker.pas
@@ -1,3 +1,33 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit AddTracker;
 
 {$mode objfpc}{$H+}

--- a/baseform.pas
+++ b/baseform.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit BaseForm;
 
 {$mode objfpc}

--- a/bencode.pas
+++ b/bencode.pas
@@ -1,3 +1,33 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit BEncode;
 
 interface

--- a/colsetup.pas
+++ b/colsetup.pas
@@ -15,6 +15,18 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
 *************************************************************************************}
 
 unit ColSetup;

--- a/connoptions.pas
+++ b/connoptions.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit ConnOptions;
 
 {$mode objfpc}{$H+}

--- a/daemonoptions.pas
+++ b/daemonoptions.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit DaemonOptions;
 
 {$mode objfpc}{$H+}

--- a/download.pas
+++ b/download.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit download;
 
 {$mode objfpc}{$H+}

--- a/ipresolver.pas
+++ b/ipresolver.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit IpResolver;
 
 {$mode objfpc}{$H+}

--- a/main.pas
+++ b/main.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit Main;
 {$mode objfpc}{$H+}
 

--- a/movetorrent.pas
+++ b/movetorrent.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit MoveTorrent;
 
 {$mode objfpc}{$H+}

--- a/options.pas
+++ b/options.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit Options;
 
 {$mode objfpc}{$H+}

--- a/passwcon.pas
+++ b/passwcon.pas
@@ -1,3 +1,33 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit passwcon;
 
 {$mode objfpc}{$H+}

--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,15 @@ Transmission Remote GUI is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
+
+In addition, as a special exception, OpenVPN Technologies, Inc. gives
+permission to link the code of this program with the OpenSSL Library (or with
+modified versions of OpenSSL that use the same license as OpenSSL), and
+distribute linked combinations including the two. You must obey the GNU General
+Public License in all respects for all of the code used other than OpenSSL. If
+you modify this file, you may extend this exception to your version of the
+file, but you are not obligated to do so. If you do not wish to do so, delete
+this exception statement from your version.
 *********************************************************************************
 
 Transmission Remote GUI is feature rich cross platform front-end to remotely control Transmission daemon via its RPC protocol. It is faster and has more functionality than builtin Transmission web interface.

--- a/restranslator.pas
+++ b/restranslator.pas
@@ -1,9 +1,34 @@
-{************************************************************
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2011-2013 by Yury Sidorov
   Copyright (c) 2010 Alex Cherednichenko, aka Alex7Che.
-  Copyright (c) 2011-2013 Yury Sidorov.
 
-  Published at GNU General Public License as Free Software.
- ************************************************************}
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 
 unit ResTranslator;
 

--- a/rpc.pas
+++ b/rpc.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit rpc;
 
 {$mode objfpc}{$H+}

--- a/torrprops.pas
+++ b/torrprops.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit TorrProps;
 
 {$mode objfpc}{$H+}

--- a/transgui.lpr
+++ b/transgui.lpr
@@ -11,6 +11,11 @@
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+  
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
 
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software

--- a/urllistenerosx.pas
+++ b/urllistenerosx.pas
@@ -1,3 +1,33 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit URLListenerOSX;
 {$mode objfpc}{$H+}
 {$modeswitch objectivec2}

--- a/utils.pas
+++ b/utils.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit utils;
 
 {$mode objfpc}{$H+}

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit VarGrid;
 
 {$mode objfpc}{$H+}

--- a/varlist.pas
+++ b/varlist.pas
@@ -15,8 +15,19 @@
   You should have received a copy of the GNU General Public License
   along with Transmission Remote GUI; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*************************************************************************************}
 
+  In addition, as a special exception, the copyright holders give permission to 
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
 unit varlist;
 
 {$mode objfpc}{$H+}


### PR DESCRIPTION
As requested by maintainers in issue #1239 
Added the OpenSSL exception to the copyright header, and added a copyright header to some files that was missing one. This sort of change should be done by the copyright holder(s), but since Transgui has been linked to OpenSSL since day one I think it is safe to assume that this was mr Sidorov's intention.