### PR TITLE
Fix absolute path error

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -933,12 +933,14 @@ begin
 
   s := CorrectPath(cbDestFolder.Text);
   e := edExtension.Text;
-  i := cbDestFolder.Items.IndexOf(s);
   try
+    DeleteDirs (0);               // check count items
+    i := cbDestFolder.Items.IndexOf(s);
     if i < 0 then begin
       DeleteDirs (1);               // prepare for new item
       cbDestFolder.Items.Add (s);
       i:=cbDestFolder.Items.IndexOf(s);
+      cbDestFolder.ItemIndex:= i; // Re-set item index in case DeleteDirs actually deleted a dir and removed the text from the combobox
       pFD    := FolderData.create;
       pFD.Hit:= 1;
       pFD.Ext:= e;
@@ -952,7 +954,9 @@ begin
       pFD.Txt:= s;
       pFD.Lst:= SysUtils.Date;
       cbDestFolder.Items.Objects[i]:= pFD;
-      DeleteDirs (0);               // check count items
+      if cbDestFolder.ItemIndex < 0 then begin // as above, if DeleteDirs ended up deleting stuff...
+        cbDestFolder.ItemIndex:= i;
+      end;
     end;
   except
     MessageDlg('Error: LS-002. Please contact the developer', mtError, [mbOK], 0);


### PR DESCRIPTION
Fixes #1270
Moves the DeleteDirs(0) call to the beginning of the try block, and re-sets ItemIndex in any situation a dir was deleted from the list (which unsets the currently selected item and sets the combobox text to an empty string).