### PR TITLE
Made taskbar button follow main form monitor (Windows)

### DIFF
--- a/transgui.lpr
+++ b/transgui.lpr
@@ -57,5 +57,10 @@ begin
 
   Application.Initialize;
   Application.CreateForm(TMainForm, MainForm);
+  
+{$ifdef windows}
+  Application.MainFormOnTaskBar:=true;  // make taskbar button follow main form monitor
+{$endif}
+
   Application.Run;
 end.


### PR DESCRIPTION
I have multiple monitors and by default transgui does not transfer taskbar button when used on a secondary monitor.
There are also these two issues mentioning the problem.
https://github.com/transmission-remote-gui/transgui/issues/1299 https://github.com/transmission-remote-gui/transgui/issues/1056

I resolved the issue with the simple suggestions in some of the linked forum articles in the issue threads.
https://forum.lazarus.freepascal.org/index.php?topic=24926.0
This allows taskbar button to move onto other monitors.
It's not perfect and sometimes I need to maximize and restore the window for the switch to happen, but at least now it's possible, while before it never happened.

On compilation I get the warning  `Warning: (5044) Symbol "MainFormOnTaskBar" is not portable`.
I don't know what the side effects of that are, so I wrapped the call in `{$ifdef windows}` just in case.