### PR TITLE
Adds IPv6 support for HTTP requests

### DIFF
--- a/synapse/source/lib/httpsend.pas
+++ b/synapse/source/lib/httpsend.pas
@@ -368,9 +368,12 @@ end;
 
 function THTTPSend.InternalConnect(needssl: Boolean): Boolean;
 begin
+  FSock.PreferIP4 := False; //try to use IPv6
   if FSock.Socket = INVALID_SOCKET then
     Result := InternalDoConnect(needssl)
   else
+    if FSock.LastError <> 0 then
+      FSock.PreferIP4 := True; //fallback to IPv4
     if (FAliveHost <> FTargetHost) or (FAlivePort <> FTargetPort)
       or FSock.CanRead(0) then
       Result := InternalDoConnect(needssl)


### PR DESCRIPTION
The `FSock.PreferIP4` setting is set to `True` which forces IPv4 only requests.

Setting it to true makes it use IPv6 but in IPv4 only clients this breaks the connectivity.

Therefore some type of IPv6 connectivity check is needed, ~which I used pinging to a the Cloudflare DNS IPv6 address with a timeout to set the setting.~

~In Linux this will only work with a sudo user as ping check needs sudo privileges on Linux.~

Best option to solve this is to implement Happy Eyeballs.

related: #1362
may be related: #1353, #485
