### PR TITLE
Remove TravisBuddy integration as it's deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,9 +173,3 @@ matrix:
 notifications:
   email:
     on_failure: true
-  webhooks:
-    urls:
-      - https://www.travisbuddy.com/
-    on_success: never
-    on_cancel: never
-    on_start: never


### PR DESCRIPTION
The project has been archived and is now read-only

Reference: https://github.com/bluzi/travis-buddy