### PR TITLE
Update node.js on Travis CI from dated v10 to v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env_template:
     <<: *linux_env
     stage: static test
     language: node_js
-    node_js: 10
+    node_js: 16
     install:
       - npm i -g $task
     before_script:


### PR DESCRIPTION
Node.js v10 is EoL-ed for a while (since 2021-04-30), would be great to update to the a newer LTS version.

As node.js v18 prebuilt binary needs newer build environment, otherwise will receive the following error:
> node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)

So just update to v16 first, and update to a new version later, after the build environment on Travis CI also updated to a new version.

Reference: https://github.com/nodejs/Release