### PR TITLE
Widen Base32 decode accumulator defensively

### DIFF
--- a/utils.pas
+++ b/utils.pas
@@ -586,7 +586,7 @@ var
   optr, len, bcnt: integer;
   Output: PByteArray;
   Input: PAnsiChar;
-  w: word;
+  w: qword;
   c: ansichar;
   b: byte;
 begin


### PR DESCRIPTION

### **User description**

## Summary

This pull request makes a small defensive change to the `Base32Decode` function in `utils.pas`. The bit accumulator used during decoding has been widened from `word` to `qword`. The current bit-buffer flow already keeps the pending bit width within the existing `word` range, so this is not a confirmed bug fix, but
it makes the accumulator more tolerant of future changes to the decoding logic.

* Changed the type of variable `w` from `word` to `qword` in the `Base32Decode` function as a defensive widening.

------
https://chatgpt.com/codex/tasks/task_e_6827859eff048327b771b3eed39a8dc3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved base32 decoding reliability, especially for larger encoded inputs.
  - Decoding now handles intermediate values more robustly, reducing the chance of incorrect output caused by intermediate overflow during the decode process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes overflow in `Base32Decode` by using a 64-bit accumulator.

- Improves reliability of Base32 decoding for large encoded values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.pas</strong><dd><code>Use 64-bit accumulator in Base32Decode to prevent overflow</code></dd></summary>
<hr>

utils.pas

<li>Changes the accumulator variable in <code>Base32Decode</code> from <code>word</code> to <code>qword</code>.<br> <li> Prevents overflow when decoding large base32 values.


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1487/files#diff-40ed7dc2f9c13ca965cb9f2993e5e3e807c8f2012e8df0573ccd2e8377495305">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>