### PR TITLE
Add Local Network permissions for macOS Sequoia

### DIFF
--- a/setup/macosx/Info.plist
+++ b/setup/macosx/Info.plist
@@ -30,6 +30,12 @@
 	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Transmission Remote GUI needs local network access to connect to Transmission daemon.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/setup/macosx/Info.plist
+++ b/setup/macosx/Info.plist
@@ -32,10 +32,6 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Transmission Remote GUI needs local network access to connect to Transmission daemon.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_http._tcp</string>
-	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Adds `NSLocalNetworkUsageDescription` to Info.plist to allow the app to appear in Local Network permission settings on macOS 15 (Sequoia) and later
- Fixes issue #1476 where users get "no route to host" error after upgrading to macOS Sequoia

## Changes
Added the following key to `setup/macosx/Info.plist`:

- `NSLocalNetworkUsageDescription`: Explains why the app needs local network access

Note: `NSBonjourServices` was considered but intentionally not added since transgui connects directly via HTTP to a user-specified host:port and does not use Bonjour service discovery.

## Testing
After applying this fix, rebuild the macOS app and it should appear in System Settings > Privacy & Security > Local Network where users can grant permission.