### PR TITLE
docs(macOS): add Gatekeeper workaround & update Homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,23 @@ This method needs no additional pre-requirement or dependency, just:
 2. Open the image file to mount the image.
 3. Directly run the application or drag the app icon to your disk / Application folder.
 
+If you run into the following error:
+
+> Apple could not verify “Transmission Remote GUI” ...
+
+See #1499 for more info. Alternatively, use the Homebrew method.
+
 #### Homebrew
 
-You need to have [Homebrew](https://brew.sh/) installed. Execute this command to install Transmission Remote Gui:
+You need to have [Homebrew](https://brew.sh/) installed. Execute these two commands to install Transmission Remote GUI:
 
-- `brew install --cask transmission-remote-gui`
+```
+brew install --cask transmission-remote-gui
+
+xattr -dr com.apple.quarantine '/Applications/Transmission Remote GUI.app'
+```
+
+See #1499 for more info on the second command.
 
 ## Command line parameters
 


### PR DESCRIPTION
- Fixes https://github.com/transmission-remote-gui/transgui/issues/1499

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates macOS install docs to explain the Gatekeeper “Apple could not verify ‘Transmission Remote GUI’” error and add a reliable workaround so the app opens after install.

Adds a short troubleshooting note linking to #1499, updates Homebrew install to two commands (`brew install --cask transmission-remote-gui` and `xattr -dr com.apple.quarantine '/Applications/Transmission Remote GUI.app'` to remove quarantine recursively), and fixes “GUI” capitalization.

<sup>Written for commit fbc83cd6e238964a244f7fc8337b0826a26ac9bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded macOS “Without a package manager” install instructions with troubleshooting for Apple’s “could not verify …” security verification error, including an example and a reference to the related discussion, plus guidance to switch to the Homebrew method instead.
  * Revised the macOS Homebrew steps for Transmission Remote GUI from a single install command to a two-step process (install the cask, then remove the quarantine attribute so the app can launch), with a reference to the same discussion for details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->