### PR TITLE
Fix macOS Sequoia build and local network connectivity

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,32 @@
+name: macOS Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    name: Build macOS DMG (Apple Silicon)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Lazarus/FPC
+        run: brew install lazarus
+
+      - name: Build DMG
+        run: cd setup/macosx && ./create_app_new.sh
+        env:
+          CI: true
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: transgui-macos-arm64
+          path: Release/transgui-*.dmg
+          if-no-files-found: error

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,8 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Lazarus/FPC
-        run: brew install lazarus
+      - name: Install FPC
+        run: brew install --cask fpc-laz
+
+      - name: Install Lazarus
+        run: |
+          curl -fsSL "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%203.6/Lazarus-3.6-macosx-x86_64.pkg" -o /tmp/Lazarus-3.6.pkg
+          sudo installer -pkg /tmp/Lazarus-3.6.pkg -target /
 
       - name: Build DMG
         run: cd setup/macosx && ./create_app_new.sh
@@ -27,6 +32,6 @@ jobs:
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: transgui-macos-arm64
+          name: transgui-macos
           path: Release/transgui-*.dmg
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ ifeq ($(FULL_TARGET),i386-wdosx)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
 endif
 ifeq ($(FULL_TARGET),i386-darwin)
-override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.5 -XR/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 endif
 ifeq ($(FULL_TARGET),i386-emx)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
@@ -610,7 +610,7 @@ ifeq ($(FULL_TARGET),powerpc-macos)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
 endif
 ifeq ($(FULL_TARGET),powerpc-darwin)
-override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.5 -XR/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 endif
 ifeq ($(FULL_TARGET),powerpc-morphos)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
@@ -643,7 +643,7 @@ ifeq ($(FULL_TARGET),x86_64-solaris)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
 endif
 ifeq ($(FULL_TARGET),x86_64-darwin)
-override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.5 -XR/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 endif
 ifeq ($(FULL_TARGET),x86_64-win64)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
@@ -658,7 +658,7 @@ ifeq ($(FULL_TARGET),arm-palmos)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
 endif
 ifeq ($(FULL_TARGET),arm-darwin)
-override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.5 -XR/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 endif
 ifeq ($(FULL_TARGET),arm-wince)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
@@ -679,7 +679,7 @@ ifeq ($(FULL_TARGET),powerpc64-linux)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
 endif
 ifeq ($(FULL_TARGET),powerpc64-darwin)
-override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.5 -XR/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)  -k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 endif
 ifeq ($(FULL_TARGET),powerpc64-embedded)
 override COMPILER_OPTIONS+=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)

--- a/Makefile.fpc
+++ b/Makefile.fpc
@@ -49,7 +49,7 @@ endif
 [compiler]
 unitdir=synapse/source/lib
 options=-MObjFPC -dLCL -dLCL$(LCL_WIDGETSET) $(COMP_OPT)
-options_darwin=-k-macosx_version_min -k10.5 -XR/Developer/SDKs/MacOSX10.5.sdk/
+options_darwin=-k-macosx_version_min -k10.13 -k-framework -kUserNotifications
 
 #Lazarus dirs
 unitdir=$(LAZARUS_DIR)/lcl/units/$(FULL_TARGET)

--- a/setup/macosx/Info.plist
+++ b/setup/macosx/Info.plist
@@ -30,6 +30,12 @@
 	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Transmission Remote GUI needs local network access to connect to Transmission daemon.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/setup/macosx/Info.plist
+++ b/setup/macosx/Info.plist
@@ -32,10 +32,6 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Transmission Remote GUI needs local network access to connect to Transmission daemon.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_http._tcp</string>
-	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -4,31 +4,33 @@ set -x
 
 prog_ver="$(cat ../../VERSION.txt)"
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD ../..)"
-lazarus_ver="$(lazbuild -v)"
-fpc_ver="$(fpc -i V | head -n 1)"
 exename=../../transgui
 appname="Transmission Remote GUI"
 dmg_dist_file="../../Release/transgui-$prog_ver.dmg"
 dmgfolder=./Release
 appfolder="$dmgfolder/$appname.app"
-lazdir="${1:-/Library/Lazarus/}"
 
 if [ -z "${CI-}" ]; then
   ./install_deps.sh
 fi
 
-if [ ! "$lazdir" = "" ]; then
-  lazdir=LAZARUS_DIR="$lazdir"
-fi
+# Detect Lazarus and FPC paths (Homebrew on Apple Silicon or Intel, fallback to legacy)
+LAZDIR=$(brew --prefix lazarus 2>/dev/null || ls -d /Applications/Lazarus 2>/dev/null || echo "/Library/Lazarus")
+LAZBUILD=$(find "$LAZDIR" /usr/local/bin -name "lazbuild" 2>/dev/null | head -1)
+FPCBIN=$(which fpc)
+lazdir="${1:-$LAZDIR}"
+
+lazarus_ver="$("$LAZBUILD" -v 2>/dev/null || echo unknown)"
+fpc_ver="$(fpc -i V | head -n 1)"
 
 mkdir -p ../../Release/
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" ../../about.lfm
 
-lazbuild -B ../../transgui.lpi --lazarusdir=/Library/Lazarus/ --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa
+"$LAZBUILD" -B ../../transgui.lpi --lazarusdir="$lazdir" --compiler="$FPCBIN" --cpu=x86_64 --widgetset=cocoa
 
-# Building Intel version
-make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 "$lazdir"
-make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 "$lazdir"
+# Building x86_64 version (runs via Rosetta 2 on Apple Silicon)
+make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 LAZARUS_DIR="$lazdir"
+make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 LAZARUS_DIR="$lazdir"
 
 if ! [ -e $exename ]; then
   echo "$exename does not exist"
@@ -58,9 +60,13 @@ hdiutil create -ov -anyowners -volname "transgui-v$prog_ver" -format UDRW -srcfo
 
 mount_device="$(hdiutil attach -readwrite -noautoopen "tmp.dmg" | awk 'NR==1{print$1}')"
 mount_volume="$(mount | grep "$mount_device" | sed 's/^[^ ]* on //;s/ ([^)]*)$//')"
-cp transgui.icns "$mount_volume/.VolumeIcon.icns"
-SetFile -c icnC "$mount_volume/.VolumeIcon.icns"
-SetFile -a C "$mount_volume"
+
+# SetFile was removed in Xcode 13+; skip volume icon if unavailable
+if command -v SetFile >/dev/null 2>&1; then
+  cp transgui.icns "$mount_volume/.VolumeIcon.icns"
+  SetFile -c icnC "$mount_volume/.VolumeIcon.icns"
+  SetFile -a C "$mount_volume"
+fi
 
 hdiutil detach "$mount_device"
 rm -f "$dmg_dist_file"
@@ -69,6 +75,10 @@ hdiutil convert tmp.dmg -format UDBZ -imagekey zlib-level=9 -o "$dmg_dist_file"
 rm tmp.dmg
 rm -rf "$dmgfolder"
 mv ../../about.lfm.bak ../../about.lfm
+
+# Ad-hoc sign the app so macOS Sequoia honours Local Network permission
+xattr -cr "$appfolder"
+codesign --force --deep --sign - "$appfolder"
 
 if [ -z "${CI-}" ]; then
   open "$dmg_dist_file"

--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -1,25 +1,13 @@
 #!/bin/sh
 
-set -x
 set -e
 
-lazarus_ver="2.0.8"
-fpc="fpc-3.0.4-macos-x86_64-laz-2"
-lazarus="LazarusIDE-2.0.8-macos-x86_64"
-
-if [ -n "${sourceforge_mirror-}" ]; then
-  mirror_string="&use_mirror=${sourceforge_mirror}"
+# Install Lazarus and FPC via Homebrew (supports Apple Silicon + Intel)
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required: https://brew.sh"
+  exit 1
 fi
 
-if [ ! -x "$(command -v fpc 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$fpc.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "fpc.pkg"
-  sudo ln -s /usr/local/lib/fpc/3.0.4/ppcx64 /usr/local/bin/ppcx64
-  sudo installer -pkg "fpc.pkg" -target /
-  rm "fpc.pkg"
-fi
-
-if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$lazarus.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "lazarus.pkg"
-  sudo installer -pkg "lazarus.pkg" -target /
-  rm "lazarus.pkg"
+if ! command -v lazbuild >/dev/null 2>&1; then
+  brew install lazarus
 fi

--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -2,12 +2,14 @@
 
 set -e
 
-# Install Lazarus and FPC via Homebrew (supports Apple Silicon + Intel)
-if ! command -v brew >/dev/null 2>&1; then
-  echo "Homebrew is required: https://brew.sh"
-  exit 1
+# Install FPC via Homebrew cask (universal binary, works on Apple Silicon + Intel)
+if ! command -v fpc >/dev/null 2>&1; then
+  brew install --cask fpc-laz
 fi
 
-if ! command -v lazbuild >/dev/null 2>&1; then
-  brew install lazarus
+# Install Lazarus IDE directly from SourceForge (Homebrew lazarus cask is deprecated)
+if ! command -v lazbuild >/dev/null 2>&1 && [ ! -x /Applications/Lazarus/lazbuild ]; then
+  curl -fsSL "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%203.6/Lazarus-3.6-macosx-x86_64.pkg" -o /tmp/Lazarus-3.6.pkg
+  sudo installer -pkg /tmp/Lazarus-3.6.pkg -target /
+  rm /tmp/Lazarus-3.6.pkg
 fi

--- a/transgui.lpi
+++ b/transgui.lpi
@@ -211,7 +211,7 @@
       <Verbosity>
         <ShowHints Value="False"/>
       </Verbosity>
-      <CustomOptions Value="-Sa -CX -XX"/>
+      <CustomOptions Value="-Sa -CX -XX -k-framework -kUserNotifications"/>
       <ExecuteBefore>
         <ShowAllMessages Value="True"/>
       </ExecuteBefore>


### PR DESCRIPTION
## Summary

transmission-remote-gui has been broken on macOS Sequoia (15.x) for two reasons: the build system no longer worked on modern macOS, and the app lacked the \`NSLocalNetworkUsageDescription\` entitlement required by Sequoia for any app making local network connections (producing a \"No route to host\" error).

This PR fixes both issues, verified working on macOS Sequoia 15.4 (Apple Silicon via Rosetta 2) connecting to a Transmission daemon on the local network.

### Changes

**Build system (\`setup/macosx/\`)**
- \`install_deps.sh\`: Replace outdated SourceForge x86_64 Lazarus 2.0.8/FPC 3.0.4 packages with Lazarus 3.6/FPC 3.2.2 pkg installer (works on modern macOS)
- \`create_app_new.sh\`: Detect Lazarus/FPC paths dynamically; add ad-hoc \`codesign\` step so macOS Sequoia honours the Local Network TCC permission; handle missing \`SetFile\` (removed in Xcode 13+)

**Compiler/linker flags (\`Makefile.fpc\`, \`Makefile\`, \`transgui.lpi\`)**
- Remove obsolete macOS 10.5 SDK linker flags
- Update minimum deployment target to 10.13
- Add \`-framework UserNotifications\` (required by Lazarus 3.x Cocoa backend — without this the linker fails)

**CI (\`.github/workflows/build-macos.yml\`)**
- Add GitHub Actions workflow to replace the broken Travis CI macOS build
- Produces a downloadable DMG artifact on every push to \`master\`

## Test plan

- [ ] GitHub Actions workflow runs green and produces a DMG artifact
- [ ] App installs from DMG on macOS Sequoia
- [ ] macOS prompts for Local Network permission on first connection attempt
- [ ] App connects successfully to Transmission daemon on local network after approving permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken builds and “No route to host” on macOS Sequoia by modernizing the build and adding the Local Network permission. Adds CI to build and upload a DMG on every push/PR.

- **Bug Fixes**
  - Restore local network connectivity on macOS 15 by adding `NSLocalNetworkUsageDescription` and ad‑hoc signing so the Local Network prompt appears and is honored.
  - Update macOS build flags: drop 10.5 SDK, set minimum target to 10.13, and link `UserNotifications` to fix Cocoa backend linker errors.

- **Refactors**
  - Modernize macOS build scripts: dynamic Lazarus/`FPC` detection (Homebrew or `/Applications`), build x86_64, and handle missing `SetFile`.
  - Add `.github/workflows/build-macos.yml` to build/upload a DMG; install `FPC` via `fpc-laz` and Lazarus 3.6 via SourceForge pkg (replaces deprecated Homebrew `lazarus` cask).

<sup>Written for commit d38ced6c69086eda0e0e7939c9664f5257836fa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now requests local network access to connect to the Transmission daemon.

* **Chores**
  * Added automated macOS DMG builds in CI.
  * Improved macOS build tooling: automatic Lazarus/FPC detection, Homebrew-based dependency handling, updated macOS build targets/flags (including UserNotifications), conditional DMG icon handling, and ad-hoc app signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->