### PR TITLE
Support OpenSSL 1.1 and 3 libraries on Linux

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -3051,6 +3051,7 @@ var
   i: integer;
 begin
   Result:=False;
+  RpcObj.InitSSL;
   tmp:=SysToUTF8(GetTempDir(True)) + 'GeoIP.dat.gz';
   if not FileExistsUTF8(tmp) or AUpdate then begin
     if MessageDlg('', sGeoIPConfirm, mtConfirmation, mbYesNo, 0, mbYes) <> mrYes then

--- a/main.pas
+++ b/main.pas
@@ -1547,6 +1547,7 @@ begin
   txTorrentHeader.Font.Size:=txTransferHeader.Font.Size;
   TrayIcon.Icon.Assign(Application.Icon);
   RpcObj:=TRpc.Create;
+  RpcObj.InitSSL;
   FTorrents:=TVarList.Create(gTorrents.Columns.Count, 0);
   FTorrents.ExtraColumns:=TorrentsExtraColumns;
   gTorrents.Items.ExtraColumns:=TorrentsExtraColumns;
@@ -3051,7 +3052,6 @@ var
   i: integer;
 begin
   Result:=False;
-  RpcObj.InitSSL;
   tmp:=SysToUTF8(GetTempDir(True)) + 'GeoIP.dat.gz';
   if not FileExistsUTF8(tmp) or AUpdate then begin
     if MessageDlg('', sGeoIPConfirm, mtConfirmation, mbYesNo, 0, mbYes) <> mrYes then

--- a/rpc.pas
+++ b/rpc.pas
@@ -618,8 +618,8 @@ procedure TRpc.InitSSL;
 {$ifndef darwin}
   procedure CheckOpenSSL;
   const
-  OpenSSLVersions: array[1..4] of string =
-  ('0.9.8', '1.0.0', '1.0.2', '1.1.0');
+  OpenSSLVersions: array[1..6] of string =
+  ('3', '1.1', '1.1.0', '1.0.2', '1.0.0', '0.9.8');
   var
     hLib1, hLib2: TLibHandle;
     i: integer;


### PR DESCRIPTION
## Fix HTTPS on modern Linux distributions

On current Linux distributions, HTTPS features such as the GeoIP database download can fail with:

> SSL/TLS support is not compiled!

even when OpenSSL is installed. This happens because the runtime OpenSSL probe does not include the library names used by newer distributions, and SSL may not be initialized when the Transmission RPC connection itself uses plain HTTP.

## Changes

- Add `libssl.so.3` / `libcrypto.so.3` detection for OpenSSL 3.
- Add `libssl.so.1.1` / `libcrypto.so.1.1` detection for OpenSSL 1.1.
- Prefer newer OpenSSL libraries before older 1.0.x / 0.9.x libraries.
- Initialize SSL during application startup after `TRpc` is created, so HTTPS downloads work even when the RPC connection uses HTTP.

## Scope

The OpenSSL SONAME probe change affects Unix builds except macOS. Windows and macOS library names are unchanged.

The startup SSL initialization runs earlier than before, but it uses the existing `TRpc.InitSSL` path and remains idempotent through `IsSSLloaded`.

## Testing

Reproduced and fixed on Debian trixie with OpenSSL 3 against a local transmission-daemon reached over plain HTTP. GeoIP download now succeeds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTPS failures on modern Linux by adding OpenSSL 3/1.1 support and initializing SSL at app startup. GeoIP and other HTTPS calls now work on Debian 12+, Ubuntu 22.04+, Fedora, Arch, etc.

- **Bug Fixes**
  - Extend the runtime `libssl` probe to include `3` and `1.1`, preferring the newest available.
  - Initialize SSL during app startup so HTTPS works even when the RPC connection uses HTTP.

<sup>Written for commit 8d0bd8a26efd6a50d9f022173b63ee0aab6b5140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSL security setup now runs during application startup, so secure connections become available earlier in the app lifecycle.
  * Enhanced Unix OpenSSL library detection by expanding and reordering the set of OpenSSL versions attempted, improving compatibility with a wider range of installed OpenSSL variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->