### PR TITLE
Support native Apple Silicon (arm64) build on macOS 26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Release/
 
 # transgui binary
 /transgui
+
+# Local Claude Code / devmode session state
+.claude/

--- a/restranslator.pas
+++ b/restranslator.pas
@@ -37,7 +37,8 @@ unit ResTranslator;
 interface
 
 uses
-  Classes, StrUtils, SysUtils, FileUtil, LazFileUtils, LResources, TypInfo, LCLProc, LazUTF8;
+  Classes, StrUtils, SysUtils, FileUtil, LazFileUtils, LResources, TypInfo, LCLProc, LazUTF8,
+  Translations;
 
 type
 
@@ -257,6 +258,19 @@ end;
 procedure SupplementTranslationFiles; overload;
 begin
   SupplementTranslationFiles(DefaultLangDir);
+end;
+
+// LazGetLanguageIDs was deprecated since Lazarus 2.3.0 and removed from LazUTF8
+// in newer Lazarus versions (use Translations.GetLanguageID instead). Provide a
+// local, version-independent equivalent so transgui builds against both the
+// 4.8 release and the development (main) branch.
+procedure LazGetLanguageIDs(var Lang, FallbackLang: String);
+var
+  LangID: TLanguageID;
+begin
+  LangID := GetLanguageID;
+  Lang := LangID.LanguageID;
+  FallbackLang := LangID.LanguageCode;
 end;
 
 procedure MakeTranslationFile; overload;

--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -2,36 +2,65 @@
 
 set -x
 
+# Build a native macOS .app + .dmg for Transmission Remote GUI.
+#
+# Latest-Mac (Apple Silicon / macOS 26 Tahoe) notes:
+#   * Default target is aarch64 (Apple Silicon). Override with CPU=x86_64.
+#   * Requires a recent Lazarus/FPC that supports aarch64-darwin Cocoa. The
+#     Lazarus 4.x "macOS aarch64" release builds work; for macOS 26 the Lazarus
+#     development (main) LCL is recommended (fewer Cocoa layout issues).
+#     Point LAZARUS_DIR / FPC at your install (see install_deps.sh).
+#   * transgui.lpi pins optimization off (-O-): FPC 3.2.4's optimizer
+#     miscompiles a virtual-method-call sequence on aarch64-darwin and corrupts
+#     the Synapse socket object, crashing on connect. Do not re-enable -O here.
+#   * The binary MUST be (re)code-signed after it is placed in the .app, or
+#     macOS 26 SIGKILLs it ("Code Signature Invalid") when it faults in code
+#     pages at runtime. We ad-hoc sign by default; set SIGN_ID to a real
+#     "Developer ID Application: ..." identity to distribute.
+
 prog_ver="$(cat ../../VERSION.txt)"
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD ../..)"
-lazarus_ver="$(lazbuild -v)"
-fpc_ver="$(fpc -i V | head -n 1)"
-exename=../../transgui
+lazarus_ver="$(lazbuild -v 2>/dev/null)"
+fpc_ver="$(fpc -i V 2>/dev/null | head -n 1)"
 appname="Transmission Remote GUI"
 dmg_dist_file="../../Release/transgui-$prog_ver.dmg"
 dmgfolder=./Release
 appfolder="$dmgfolder/$appname.app"
-lazdir="${1:-/Library/Lazarus/}"
+
+# Configurable toolchain / target (sane defaults for Apple Silicon).
+CPU="${CPU:-aarch64}"
+LAZARUS_DIR="${LAZARUS_DIR:-${1:-/Library/Lazarus/}}"
+FPC="${FPC:-/usr/local/bin/fpc}"
+SIGN_ID="${SIGN_ID:--}"   # "-" = ad-hoc; or a Developer ID identity name
 
 if [ -z "${CI-}" ]; then
   ./install_deps.sh
 fi
 
-if [ ! "$lazdir" = "" ]; then
-  lazdir=LAZARUS_DIR="$lazdir"
-fi
-
 mkdir -p ../../Release/
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" ../../about.lfm
 
-lazbuild -B ../../transgui.lpi --lazarusdir=/Library/Lazarus/ --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa
+# Build (lazbuild also builds the required local package trcomp and produces the
+# executable; the lpi carries the cocoa/-O- settings).
+lazbuild -B ../../trcomp.lpk ../../transgui.lpi \
+  --lazarusdir="$LAZARUS_DIR" --compiler="$FPC" --cpu="$CPU" --widgetset=cocoa
+rc=$?
 
-# Building Intel version
-make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 "$lazdir"
-make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 "$lazdir"
+# Restore about.lfm regardless of build outcome.
+mv ../../about.lfm.bak ../../about.lfm 2>/dev/null
 
-if ! [ -e $exename ]; then
-  echo "$exename does not exist"
+if [ "$rc" != 0 ]; then
+  echo "lazbuild failed (rc=$rc)"
+  exit 1
+fi
+
+# lazbuild may place the binary in the project root or the unit output dir.
+exename=""
+for cand in ../../transgui ../../units/transgui; do
+  if [ -e "$cand" ]; then exename="$cand"; break; fi
+done
+if [ -z "$exename" ]; then
+  echo "built transgui binary not found"
   exit 1
 fi
 strip "$exename"
@@ -42,7 +71,7 @@ echo "Creating $appfolder..."
 mkdir -p "$appfolder/Contents/MacOS/lang"
 mkdir -p "$appfolder/Contents/Resources"
 
-mv "$exename" "$appfolder/Contents/MacOS"
+mv "$exename" "$appfolder/Contents/MacOS/transgui"
 cp ../../lang/transgui.* "$appfolder/Contents/MacOS/lang"
 
 cp ../../history.txt "$dmgfolder"
@@ -51,6 +80,10 @@ cp ../../README.md "$dmgfolder"
 cp PkgInfo "$appfolder/Contents"
 cp transgui.icns "$appfolder/Contents/Resources"
 sed -e "s/@prog_ver@/$prog_ver/" Info.plist > "$appfolder/Contents/Info.plist"
+
+# Code-sign the finished bundle (required on Apple Silicon / macOS 26).
+codesign --force --deep --options runtime --sign "$SIGN_ID" "$appfolder"
+codesign --verify --verbose=2 "$appfolder" || { echo "codesign verification failed"; exit 1; }
 
 ln -s /Applications "$dmgfolder/Drag \"Transmission Remote GUI\" here!"
 
@@ -68,7 +101,6 @@ hdiutil convert tmp.dmg -format UDBZ -imagekey zlib-level=9 -o "$dmg_dist_file"
 
 rm tmp.dmg
 rm -rf "$dmgfolder"
-mv ../../about.lfm.bak ../../about.lfm
 
 if [ -z "${CI-}" ]; then
   open "$dmg_dist_file"

--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -3,23 +3,44 @@
 set -x
 set -e
 
-lazarus_ver="2.0.8"
-fpc="fpc-3.0.4-macos-x86_64-laz-2"
-lazarus="LazarusIDE-2.0.8-macos-x86_64"
+# Install a Lazarus/FPC toolchain for building Transmission Remote GUI on macOS.
+#
+# Defaults target Apple Silicon (aarch64) using the Lazarus team's official
+# "macOS aarch64" release builds. For Intel, set ARCH=x86-64 (and adjust the
+# file names below to the matching x86-64 release).
+#
+# NOTE for macOS 26 (Tahoe): the released LCL still has Cocoa layout-recursion
+# issues on Tahoe. If you hit UI instability, build the Lazarus development
+# (main) branch instead and point create_app_new.sh at it via LAZARUS_DIR.
+
+lazarus_ver="4.8"
+fpc_dmg="fpc-3.2.4rc1a.intelarm64-macosx.dmg"
+fpc_pkg_glob="fpc-*-macosx.pkg"
+lazarus_zip="lazarus-darwin-aarch64-${lazarus_ver}.zip"
+sf_base="https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20aarch64/Lazarus%20${lazarus_ver}"
+lazarus_dest="${LAZARUS_DEST:-$HOME/lazarus}"
 
 if [ -n "${sourceforge_mirror-}" ]; then
   mirror_string="&use_mirror=${sourceforge_mirror}"
 fi
 
+# --- FPC compiler (system install, needs sudo) ---
 if [ ! -x "$(command -v fpc 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$fpc.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "fpc.pkg"
-  sudo ln -s /usr/local/lib/fpc/3.0.4/ppcx64 /usr/local/bin/ppcx64
-  sudo installer -pkg "fpc.pkg" -target /
-  rm "fpc.pkg"
+  curl -fL "${sf_base}/${fpc_dmg}?r=&ts=$(date +%s)${mirror_string-}" -o "fpc.dmg"
+  mount_point="$(hdiutil attach -nobrowse -readonly fpc.dmg | awk 'END{$1="";$2="";sub(/^  */,"");print}')"
+  sudo installer -pkg "$mount_point"/$fpc_pkg_glob -target /
+  hdiutil detach "$mount_point"
+  rm -f fpc.dmg
 fi
 
-if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$lazarus.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "lazarus.pkg"
-  sudo installer -pkg "lazarus.pkg" -target /
-  rm "lazarus.pkg"
+# --- Lazarus IDE / LCL (portable zip, no sudo) ---
+if [ ! -x "$(command -v lazbuild 2>&1)" ] && [ ! -x "$lazarus_dest/lazbuild" ]; then
+  curl -fL "${sf_base}/${lazarus_zip}?r=&ts=$(date +%s)${mirror_string-}" -o "lazarus.zip"
+  # Unmark quarantine before unzipping (required by the Lazarus macOS README).
+  xattr -c lazarus.zip 2>/dev/null || true
+  mkdir -p "$lazarus_dest"
+  unzip -oq lazarus.zip -d "$lazarus_dest"
+  rm -f lazarus.zip
+  echo "Lazarus extracted to: $lazarus_dest"
+  echo "Build with:  LAZARUS_DIR=\"$lazarus_dest\" ./create_app_new.sh"
 fi

--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -113,8 +113,13 @@ const
 var
   {$IFNDEF MSWINDOWS}
     {$IFDEF DARWIN}
-    DLLSSLName: string = 'libssl.dylib';
-    DLLUtilName: string = 'libcrypto.dylib';
+    // Modern macOS (Sequoia/Tahoe and later) aborts the process when an
+    // *unversioned* libcrypto.dylib / libssl.dylib is dlopen'ed ("Invalid
+    // dylib load ... does not have a stable ABI"). Default to versioned
+    // names and resolve real candidates in InitSSLInterface (see DARWIN
+    // fallback block) so the app never loads the guarded unversioned lib.
+    DLLSSLName: string = 'libssl.3.dylib';
+    DLLUtilName: string = 'libcrypto.3.dylib';
     {$ELSE}
      {$IFDEF OS2}
       {$IFDEF OS2GCC}
@@ -1859,8 +1864,30 @@ begin
 {$ENDIF}
 end;
 
+{$IFDEF DARWIN}
+// Try a list of candidate dylib names/paths, returning the first that loads.
+// Used on macOS to avoid the (now fatal) unversioned libcrypto/libssl load.
+function LoadLibList(const Names: array of string): HModule;
+var
+  i: Integer;
+begin
+  Result := 0;
+  for i := Low(Names) to High(Names) do
+  begin
+    if Names[i] = '' then
+      Continue;
+    Result := LoadLib(Names[i]);
+    if Result <> 0 then
+      Exit;
+  end;
+end;
+{$ENDIF}
+
 function InitSSLInterface: Boolean;
 var
+{$IFDEF DARWIN}
+  ExeDir: string;
+{$ENDIF}
   s: string;
   x: integer;
 begin
@@ -1886,6 +1913,33 @@ begin
         SSLLibHandle := LoadLib(DLLSSLName2);
       if (SSLUtilHandle = 0) then
         SSLUtilHandle := LoadLib(DLLUtilName2);
+  {$ENDIF}
+  {$IFDEF DARWIN}
+      // Resolve a real (versioned) OpenSSL: bundled inside the .app first,
+      // then common Homebrew prefixes, then versioned names on the default
+      // search path. The unversioned libcrypto.dylib/libssl.dylib are never
+      // tried because modern macOS aborts the process if they are loaded.
+      ExeDir := ExtractFilePath(ParamStr(0));
+      if (SSLUtilHandle = 0) then
+        SSLUtilHandle := LoadLibList([
+          ExeDir + 'libcrypto.3.dylib',
+          ExeDir + '../Frameworks/libcrypto.3.dylib',
+          '/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib',
+          '/usr/local/opt/openssl@3/lib/libcrypto.3.dylib',
+          '/opt/homebrew/opt/openssl@1.1/lib/libcrypto.1.1.dylib',
+          '/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib',
+          'libcrypto.3.dylib',
+          'libcrypto.1.1.dylib']);
+      if (SSLLibHandle = 0) then
+        SSLLibHandle := LoadLibList([
+          ExeDir + 'libssl.3.dylib',
+          ExeDir + '../Frameworks/libssl.3.dylib',
+          '/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib',
+          '/usr/local/opt/openssl@3/lib/libssl.3.dylib',
+          '/opt/homebrew/opt/openssl@1.1/lib/libssl.1.1.dylib',
+          '/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib',
+          'libssl.3.dylib',
+          'libssl.1.1.dylib']);
   {$ENDIF}
 {$ENDIF}
       if (SSLLibHandle <> 0) and (SSLUtilHandle <> 0) then

--- a/transgui.lpi
+++ b/transgui.lpi
@@ -205,13 +205,13 @@
       </SyntaxOptions>
     </Parsing>
     <CodeGeneration>
-      <SmallerCode Value="True"/>
+      <SmallerCode Value="False"/>
     </CodeGeneration>
     <Other>
       <Verbosity>
         <ShowHints Value="False"/>
       </Verbosity>
-      <CustomOptions Value="-Sa -CX -XX"/>
+      <CustomOptions Value="-Sa -CX -XX -O-"/>
       <ExecuteBefore>
         <ShowAllMessages Value="True"/>
       </ExecuteBefore>


### PR DESCRIPTION
Make Transmission Remote GUI build and run natively on the latest Mac (macOS 26 "Tahoe", Apple Silicon). Four issues had to be addressed:

* SSL startup abort: macOS 26's dyld aborts the process when an unversioned libcrypto.dylib / libssl.dylib is dlopen'ed. Default the Darwin SSL library names to versioned ones and resolve a real OpenSSL (bundled / Homebrew / versioned) in InitSSLInterface, never loading the guarded unversioned system lib. (synapse/source/lib/ssl_openssl_lib.pas)

* Newer-Lazarus build break: LazGetLanguageIDs was removed from LazUTF8. Provide a local, version-independent equivalent via Translations. GetLanguageID so the project builds against both Lazarus 4.x and main. (restranslator.pas)

* Connect crash: FPC 3.2.4's optimizer (>= -O1) miscompiles a virtual method call sequence on aarch64-darwin, corrupting the Synapse socket object and crashing when connecting to the daemon. Disable optimization (-O-, SmallerCode off) as a workaround. (transgui.lpi)

* Build packaging: target aarch64, build via lazbuild, and code-sign the finished .app — macOS 26 SIGKILLs an invalidly-signed binary when it faults in code pages at runtime. Refresh install_deps.sh to fetch the aarch64 toolchain. (setup/macosx/*)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native Apple Silicon (arm64) support for macOS 26 (Tahoe) and fix SSL startup aborts and connect crashes. Build now targets aarch64 by default and produces a code-signed .app.

- **Bug Fixes**
  - Prevent SSL abort on macOS 26 by defaulting to `libssl.3.dylib`/`libcrypto.3.dylib` and resolving a real OpenSSL from the app bundle, `Homebrew` (`openssl@3`/`openssl@1.1`), or versioned paths; never load unversioned libs.
  - Replace removed `LazGetLanguageIDs` with a local wrapper over `Translations.GetLanguageID` to build on Lazarus 4.x and main.
  - Work around FPC 3.2.4 aarch64-darwin optimizer miscompile by disabling optimization (`-O-`, SmallerCode off).

- **Migration**
  - Default build target is `aarch64`; override with `CPU=x86_64` if needed.
  - Install the Apple Silicon toolchain via `setup/macosx/install_deps.sh` (Lazarus 4.8, FPC 3.2.4 rc), then build with `setup/macosx/create_app_new.sh` using `LAZARUS_DIR`/`FPC` as needed.
  - The `.app` is code-signed; set `SIGN_ID` to a real "Developer ID Application" for distribution (ad-hoc by default).

<sup>Written for commit a97d5b7b71e57a56f6aaa01a2f5ec07b86d031d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple Silicon (ARM64) native build support with configurable toolchain/target selection.
  * Improved macOS app bundle code-signing with runtime options and strict verification.

* **Bug Fixes**
  * Enhanced macOS build reliability (better error handling, fixed binary placement, and bundle contents checks).
  * Improved OpenSSL dynamic library loading on macOS by preferring versioned dylibs.

* **Chores**
  * Updated translation language ID handling for broader Lazarus compatibility.
  * Updated build ignores and adjusted compiler code generation/verbosity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->