### PR TITLE
Anchor over-broad `lib/` and `units/` `.gitignore` patterns to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@
 # These can be changed by user in Lazarus/project options.
 backup/
 *.bak
-lib/
-units/
+/lib/
+/units/
 
 # Application bundle for Mac OS
 *.app/


### PR DESCRIPTION
Besides the intended Lazarus build output at the repo root (`./lib`, `./units`) they also match and silently ignore any same-named directories deeper in the repo. Notably, `synapse/source/lib/`

This merely adds `/` to the start of `lib/` and `utils/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchor the `lib/` and `units/` patterns in `.gitignore` to the repo root. Root-level Lazarus build outputs (`./lib`, `./units`) stay ignored, while nested paths like `synapse/source/lib/` are now tracked.

<sup>Written for commit b53330aab5c5d94e9683bb690de4b5421ebe5707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to more precisely exclude project artifact folders, specifically `/lib/` and `/units/`, from version control to keep the workspace cleaner and reduce accidental commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->