### PR TITLE
macos: freeze light/dark appearance at launch to avoid UI corruption

### DIFF
--- a/maclocale.pas
+++ b/maclocale.pas
@@ -20,13 +20,20 @@
 unit MacLocale;
 
 {$mode objfpc}{$H+}
+{$modeswitch objectivec1}  // for the Cocoa appearance API in PinCurrentAppearance
 
 interface
 
 uses
-  SysUtils, MacOSAll;
+  SysUtils, MacOSAll
+{$ifdef LCLCocoa}
+, CocoaAll, Cocoa_Extra // for effectiveAppearance, setAppearance and NSAppKitVersionNumber10_14
+{$endif}
+;
 
 procedure GetMacFormatSettings(var ASettings: TFormatSettings);
+
+procedure PinCurrentAppearance;
 
 implementation
 
@@ -280,6 +287,29 @@ begin
     end;
     CFRelease(loc);
   end;
+end;
+
+procedure PinCurrentAppearance;
+{$ifdef LCLCocoa}
+var
+  app: NSApplication;
+  current: NSAppearance;
+{$endif}
+begin
+{$ifdef LCLCocoa}
+  if NSApp = nil then
+    Exit;
+  // effectiveAppearance / setAppearance are AppKit 10.14+; do nothing on older
+  // systems (which have no Dark mode to follow anyway).
+  if NSAppKitVersionNumber < NSAppKitVersionNumber10_14 then
+    Exit;
+  app := NSApplication(NSApp);
+  // Resolve the appearance the system currently wants, then pin the app to that
+  // concrete instance so AppKit stops following later system changes.
+  current := app.effectiveAppearance;
+  if current <> nil then
+    app.setAppearance(current);
+{$endif}
 end;
 
 initialization

--- a/macos-light-dark-mode-problem.md
+++ b/macos-light-dark-mode-problem.md
@@ -1,0 +1,121 @@
+# Fix: live Light/Dark appearance switching on macOS
+
+**Status:** deferred/on-hold, with a partial investigation recorded below so
+the next attempt does not repeat dead ends. A new stopgap fix is committed that
+freezes the palette so the app doesn't react to the system appearance change,
+rather than the existing behaviour of a partial and unreadable halfway-house.
+
+The launch-time appearance pin (`MacLocale.PinCurrentAppearance`, called from
+`transgui.lpr`), which this work would eventually replace.
+
+## What the pin does, and why it's a stopgap
+
+Native macOS apps follow the system appearance live: flip System Settings →
+Appearance and the UI recolours instantly. _transgui_ does not — flip the
+appearance while it is running and the torrent/peer/file/tracker grids are left
+half-light/half-dark until restart. Generally, stock widgets behave, but the
+custom widgets don't.
+
+`MacLocale.PinCurrentAppearance` (called from `transgui.lpr`) sidesteps this
+by locking the app to its launch appearance so it is at least consistent.
+
+The correct idiomatic behaviour for a Mac app would be to correctly and entirely
+update when the system updates. However, this has proven harder than estimated.
+
+## Investigation: the real root cause (read this first)
+
+An initial, plausible-sounding theory was: "_transgui_ caches derived colours at
+form-create time (e.g. `FAlterColor` in `main.pas`, the grid `AlternateColor`),
+so just recompute them and force a repaint."
+
+**This is wrong, and testing disproves it**:
+
+- Scrolling, resizing, reconnecting, moving columns, toggling panes and going
+  fullscreen all repaint the grids, yet the wrong colours persist. So a repaint
+  is not the missing ingredient, and the stale value is not merely a cached
+  transgui property.
+
+- Recomputing `AlternateColor` live in `TVarGrid.PrepareCanvas` (tried) would
+  derive it from the grid's `Color`, which resolves through the *same* stale
+  path — so it does not help either.
+
+The actual cause is one level down, in how the LCL Cocoa widgetset resolves
+symbolic system colours to concrete RGB:
+
+- _transgui_ uses `clWindow` / `clBtnFace` / `clHighlight` / `clWindowText` 
+  for the grid backgrounds, the alternating-row shade, selection and text.
+
+- On Cocoa these map to **dynamic `NSColor`s** — see
+  `lcl/interfaces/cocoa/cocoautils.pas`, `TCocoaColorUtil.sysIndexToColor`:
+  
+  `COLOR_WINDOW → NSColor.textBackgroundColor`,
+  `COLOR_BTNFACE → NSColor.controlBackgroundColor`,
+  `COLOR_HIGHLIGHT → NSColor.selectedControlColor`, etc.
+
+- A dynamic `NSColor` only yields the *current* appearance's RGB when it is
+  evaluated inside a drawing context whose `NSAppearance` is current. The stock
+  chrome (toolbar, headers, tabs, status bar) recolours correctly because AppKit
+  draws it in that context. The custom grid converts the symbolic colour to an
+  absolute `TColor`/RGB **outside** a current-appearance context, so it freezes
+  at the launch appearance's values and no amount of repainting refreshes it.
+
+In short: the problem is **frozen dynamic-NSColor resolution for the custom
+grid**, not a _transgui_-level colour cache.
+
+## What a proper implementation needs
+
+1. **Resolve system colours live, in-context.** In the grid's paint path,
+   obtain the background / alternate / text / selection colours by evaluating
+   the corresponding dynamic `NSColor` (`textBackgroundColor`,
+   `controlBackgroundColor`, `selectedControlColor`, `controlTextColor`, …)
+   within the current `NSAppearance` drawing context, then convert to `TColor`
+   for that draw — rather than reading a pre-resolved `clWindow` value. This is
+   the crux and it couples `vargrid.pas` (or a small Cocoa helper it calls) to
+   the Cocoa widgetset. Investigate whether wrapping the draw in
+   `NSAppearance.performAsCurrentDrawingAppearance` (10.16+) or setting
+   `NSAppearance.setCurrentAppearance` around the conversion is enough.
+
+2. **Derive the alternate-row shade from that live base colour** (the existing
+   `GetLikeColor(base, -$10)` rule), each paint, instead of the stored
+   `AlternateColor`.
+
+3. **Trigger a repaint on appearance change.** Register an `ICocoaThemeObserver`
+   (`TCocoaThemeServices.addObserver`, fired from `doDarwinThemeChangedNotify`)
+   or hook `AppleInterfaceThemeChangedNotification`, and `Invalidate` the main
+   form and grids. Note the LCL already calls `UpdateThemes` /
+   `Graphics.UpdateHandleObjects` / `IntfDoOnThemeChange` here — confirm what
+   that does and does not refresh before adding more.
+
+4. **Re-apply state-dependent backgrounds.** The grid `.Color` is set per
+   connection state (`clWindow` when connected, `clBtnFace` when disconnected;
+   see `DoDisconnect` and the connect path in `main.pas`). Any refresh must read
+   the current state, not assume one.
+
+5. **Disable the pin** (undo this commit) once live refresh works.
+
+## Risks / unknowns
+
+- The fix is concentrated in `vargrid.pas` custom drawing, which already carries
+  an LCL-bug workaround in `PrepareCanvas` — delicate territory.
+  
+- The combinatorial test surface is large and hard to drive: **appearance change ×
+  connection state × which of the 14 dialogs is open × transient UI state**. 
+  
+  A realistic plan tests the main window across connected/disconnected × light/dark
+  and treats dialogs as recolouring on reopen. Any implementation must be
+  safe-by-construction (no new crashes) even in untested corners, since it cannot
+  be exhaustively verified.
+
+- Saying that, fixing the most common cases would be better than the status
+  quo, but the pin is a big improvement over a largely unreadable mixture,
+  for the most part wholly acceptable, and if it's too annoying, resolving 
+  just involves quickly restarting the app.
+
+## Effort estimate
+
+It's a larger effort than originally estimated; mainly due to the manual testing
+that would be required and difficult to automate. The risk lives in the Cocoa
+colour-resolution plumbing, not the LCL-level wiring, so it'd be fiddly and
+add more platform-specific code. Because the launch-time pin already yields
+a more usable app, the choice has been to just document the problem for
+possible future effort.

--- a/transgui.lpr
+++ b/transgui.lpr
@@ -56,6 +56,14 @@ begin
   if not CheckAppParams then exit;
 
   Application.Initialize;
+
+{$ifdef darwin}
+  // Pin the macOS appearance (light/dark) to its launch state. Stopgap
+  // until live appearance tracking is implemented; see MacLocale and
+  // `macos-light-dark-mode-problem.md` for details.
+  PinCurrentAppearance;
+{$endif}
+
   Application.CreateForm(TMainForm, MainForm);
   
 {$ifdef windows}


### PR DESCRIPTION
Fixes #1268, #1289, #1320, #1366 … or at least mitigates the problem.
    
When macOS's appearance flips from light to dark or vice versa, the app's grids update incompletely, making it difficult to read the interface. This can be fixed simply by restarting the app, but it's irritating.
    
Pin the application to whatever appearance is active at launch, so it stays consistent for the session. 

A proper fix was considered and attempted, but proved easier said than done, so this is a deliberate stopgap to make the problem more tolerable. The fault and a potential fix is covered in detail in `macos-light-dark-mode-problem.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze macOS light/dark appearance at app launch to prevent half-updated grid colors when the system toggles modes. Keeps the UI consistent for the whole session.

- **Bug Fixes**
  - Implemented `PinCurrentAppearance` to set the app’s `NSAppearance` to the current `effectiveAppearance` at startup; invoked after `Application.Initialize` on `darwin`.
  - Guarded for `LCLCocoa` and AppKit 10.14+; no-op when `NSApp` is nil or on non-Cocoa platforms.
  - Added `macos-light-dark-mode-problem.md` documenting the root cause and the plan for a proper live-tracking fix.

<sup>Written for commit 429e2552e3866317ac0c30449a394172cbc05382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS light/dark appearance handling by syncing the app with the system’s launch appearance, preventing grid and color styling from drifting out of sync during theme changes.

* **Documentation**
  * Added documentation describing the current macOS live Light/Dark switching problem, the stopgap workaround used to stabilize appearance/palette behavior, and a proposed plan for a complete future fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->