### PR TITLE
Use archive mirrors to revive aging Docker build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,14 +99,14 @@ matrix:
       env:
         - task=zip-tarball-test
       script:
-        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" debian:buster-backports bash -c "cd /transgui/ && ./setup/unix/debian-ubuntu-install_deps.sh && lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/ && make -j$(nproc) zipdist && ls -al ./Release/transgui-$PROG_VER-x86_64-linux.zip"
+        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" debian:buster-backports bash -c "cd /transgui/ && ./setup/unix/use-buster-archive-apt.sh debian && ./setup/unix/debian-ubuntu-install_deps.sh && lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/ && make -j$(nproc) zipdist && ls -al ./Release/transgui-$PROG_VER-x86_64-linux.zip"
 
     - <<: *linux_build_env
       env:
         - arch=amd64
         - artifact=./Release/transgui-$PROG_VER-x86_64-Linux.txz
       script:
-        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" debian:buster-backports bash -c "cd /transgui/setup/unix/ && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
+        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" debian:buster-backports bash -c "cd /transgui/setup/unix/ && ./use-buster-archive-apt.sh debian && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
       after_success: *linux_after_success
       deploy: *deploy
 
@@ -115,7 +115,7 @@ matrix:
         - arch=i386
         - artifact=./Release/transgui-$PROG_VER-i686-Linux.txz
       script:
-        - docker run -e DEBIAN_FRONTEND=noninteractive --privileged -it --rm -v "${PWD}:/transgui" i386/debian:buster-backports linux32 --32bit bash -c "cd /transgui/setup/unix/ && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
+        - docker run -e DEBIAN_FRONTEND=noninteractive --privileged -it --rm -v "${PWD}:/transgui" i386/debian:buster-backports linux32 --32bit bash -c "cd /transgui/setup/unix/ && ./use-buster-archive-apt.sh debian && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
       after_success: *linux_after_success
       deploy: *deploy
 
@@ -128,7 +128,7 @@ matrix:
           packages:
             - qemu-user-static
       script:
-        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static balenalib/rpi-raspbian:buster bash -c "sed -i 's/archive.raspbian.org/mirrors.ocf.berkeley.edu\/raspbian/g' /etc/apt/sources.list && cd /transgui/setup/unix/ && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
+        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static balenalib/rpi-raspbian:buster bash -c "cd /transgui/setup/unix/ && ./use-buster-archive-apt.sh raspbian && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
       after_success: *linux_after_success
       deploy: *deploy
 
@@ -141,7 +141,7 @@ matrix:
           packages:
             - qemu-user-static
       script:
-        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static balenalib/armv7hf-debian:buster bash -c "cd /transgui/setup/unix/ && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
+        - docker run -e DEBIAN_FRONTEND=noninteractive -it --rm -v "${PWD}:/transgui" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static balenalib/armv7hf-debian:buster bash -c "cd /transgui/setup/unix/ && ./use-buster-archive-apt.sh debian && ./debian-ubuntu-install_deps.sh && apt upgrade -y && git config --global --add safe.directory /transgui && ./build.sh"
       after_success: *linux_after_success
       deploy: *deploy
 

--- a/setup/unix/use-buster-archive-apt.sh
+++ b/setup/unix/use-buster-archive-apt.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -ex
+
+case "${1-}" in
+  debian)
+    printf '%s\n' 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+      [ -f "$source_file" ] || continue
+      sed -i \
+        -e "s|http://deb.debian.org/debian|http://archive.debian.org/debian|g" \
+        -e "s|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g" \
+        -e "s|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g" \
+        "$source_file"
+    done
+    ;;
+  raspbian)
+    printf '%s\n' 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+      [ -f "$source_file" ] || continue
+      sed -i \
+        -e "s|http://archive.raspbian.org/raspbian|http://legacy.raspbian.org/raspbian|g" \
+        -e "s|http://raspbian.raspberrypi.org/raspbian|http://legacy.raspbian.org/raspbian|g" \
+        -e "s|http://mirrordirector.raspbian.org/raspbian|http://legacy.raspbian.org/raspbian|g" \
+        -e "s|http://mirrors.ocf.berkeley.edu/raspbian/raspbian|http://legacy.raspbian.org/raspbian|g" \
+        "$source_file"
+    done
+    ;;
+  *)
+    echo "Usage: $0 debian|raspbian" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The Linux build jobs still rely on Buster-based Docker images, but those images now point at apt mirrors that no longer serve every required suite. As a result, CI and local Docker rebuilds fail during apt update before reaching the existing Lazarus/FPC build steps.

Add a small setup helper that switches the affected Debian and Raspbian Buster sources to archive mirrors and disables Valid-Until checks for those archived indexes. Wire it into the existing Buster jobs before installing build dependencies.

Keep the change limited to restoring the old build path so the aging CI pipeline can run again without changing the build scripts themselves.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore failing Buster-based Docker builds by switching APT to archive mirrors and disabling Valid-Until checks, with an explicit distro target, so CI and local rebuilds run again without changing existing build steps.

- **Bug Fixes**
  - Added `setup/unix/use-buster-archive-apt.sh` to rewrite APT sources for Debian (`archive.debian.org`) and Raspbian (`legacy.raspbian.org`), requiring an explicit `debian` or `raspbian` target.
  - Disabled APT "Valid-Until" to accept archived indexes.
  - Updated `.travis.yml` to run the helper in all Buster jobs (amd64, i386, ARM, RPi) before installing dependencies, replacing the ad-hoc Raspbian mirror tweak.

<sup>Written for commit 7a2a2a4aefa78e6c6d1586dfb32f6cbddb575465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux and Raspberry Pi build reliability by updating CI package source handling before installing dependencies.
  * Reduced build failures from outdated or unreachable apt repositories by redirecting Debian and Raspbian apt sources to archival locations when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->