### PR TITLE
Stabilize ARM Lazarus builds and variant rows

### DIFF
--- a/setup/unix/build.sh
+++ b/setup/unix/build.sh
@@ -4,6 +4,21 @@ set -ex
 
 ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../" && pwd)"
 VERSION="$(cat "$ROOT/VERSION.txt")"
+ARCH="$(uname -m)"
+LAZARUS_DIR="/usr/lib/lazarus/default"
+LAZARUS_PCP="$(mktemp -d "/tmp/lazarus-pcp-transgui-${ARCH}.XXXXXX")"
+trap 'rm -rf "${LAZARUS_PCP:?}"' EXIT
+
+cleanup_lazbuild_state() {
+  rm -rf "${ROOT:?}/units" "${ROOT:?}/lib"
+  mkdir -p "${ROOT:?}/units" "${ROOT:?}/lib" "${LAZARUS_PCP:?}"
+}
+
+run_lazbuild() {
+  cleanup_lazbuild_state
+  lazbuild -B "$ROOT/trcomp.lpk" --lazarusdir="$LAZARUS_DIR" --pcp="$LAZARUS_PCP"
+  lazbuild -B "$ROOT/transgui.lpi" --lazarusdir="$LAZARUS_DIR" --pcp="$LAZARUS_PCP"
+}
 
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD)"
 lazarus_ver="$(lazbuild -v)"
@@ -11,7 +26,7 @@ fpc_ver="$(fpc -i V | head -n 1)"
 
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" "$ROOT/about.lfm"
 
-lazbuild -B "$ROOT/transgui.lpi" --lazarusdir=/usr/lib/lazarus/default/
+run_lazbuild
 make -C "$ROOT" -j"$(nproc)" clean
 make -C "$ROOT" -j"$(nproc)" all
 

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -1086,21 +1086,20 @@ var
   v: variant;
   dc: integer;
 begin
-  if (ACol < 0) or (ARow < 0) then
-    exit;
+  CellAttribs.Text:='';
   CellAttribs.ImageIndex:=-1;
   CellAttribs.Indent:=0;
   CellAttribs.Options:=[];
   CellAttribs.State:=cbUnchecked;
   CellAttribs.Expanded:=True;
+  if (ACol < 0) or (ARow < 0) then
+    exit;
   if ACol >= FixedCols then begin
     dc:=ColToDataCol(ACol);
     if ARow >= FixedRows then begin
       v:=Items[dc, ARow - FixedRows];
       if not VarIsNull(v) and not VarIsEmpty(v) then
         CellAttribs.Text:=UTF8Encode(WideString(v))
-      else
-        CellAttribs.Text:='';
     end
     else
       CellAttribs.Text:=ColumnFromGridColumn(ACol).Title.Caption;
@@ -1202,8 +1201,12 @@ end;
 
 destructor TVarGrid.Destroy;
 begin
+  if FItems <> nil then begin
+    FItems.OnDataChanged:=nil;
+    FItems.Free;
+    FItems:=nil;
+  end;
   inherited Destroy;
-  FItems.Free;
 end;
 
 function TVarGrid.EditorByStyle(Style: TColumnButtonStyle): TWinControl;

--- a/varlist.pas
+++ b/varlist.pas
@@ -152,20 +152,61 @@ end;
 
 procedure TVarList.SetColCnt(const AValue: integer);
 var
-  i, j, ocnt, ncnt: integer;
-  p: PVariant;
+  i, j, ocnt, ncnt, copycnt: integer;
+  oldrow, newrow: PVariant;
+  newrows: TList;
 begin
+  if AValue < 0 then
+    raise Exception.Create('Invalid column count.');
   if FColCnt = AValue then exit;
   ocnt:=FColCnt + IntCols;
-  FColCnt:=AValue;
-  ncnt:=FColCnt + IntCols;
-  for i:=0 to Count - 1 do begin
-    p:=GetRow(i);
-    for j:=ncnt to ocnt - 1 do
-      VarClear(p[j]);
-    ReAllocMem(p, ncnt*SizeOf(variant));
-    if ncnt > ocnt then
-      FillChar(p[ocnt], (ncnt - ocnt)*SizeOf(variant), 0);
+  ncnt:=AValue + IntCols;
+  copycnt:=Min(ocnt, ncnt);
+  newrows:=TList.Create;
+  try
+    newrows.Capacity:=Count;
+    for i:=0 to Count - 1 do
+      newrows.Add(nil);
+
+    for i:=0 to Count - 1 do begin
+      oldrow:=inherited Get(i);
+      if oldrow = nil then
+        continue;
+      newrow:=AllocMem(ncnt*SizeOf(variant));
+      try
+        for j:=0 to copycnt - 1 do
+          newrow[j]:=oldrow[j];
+      except
+        for j:=0 to ncnt - 1 do
+          VarClear(newrow[j]);
+        FreeMem(newrow);
+        raise;
+      end;
+      newrows[i]:=newrow;
+    end;
+
+    for i:=0 to Count - 1 do begin
+      newrow:=newrows[i];
+      if newrow = nil then
+        continue;
+      oldrow:=inherited Get(i);
+      Put(i, newrow);
+      newrows[i]:=nil;
+      for j:=0 to ocnt - 1 do
+        VarClear(oldrow[j]);
+      FreeMem(oldrow);
+    end;
+    FColCnt:=AValue;
+  finally
+    for i:=0 to newrows.Count - 1 do begin
+      newrow:=newrows[i];
+      if newrow <> nil then begin
+        for j:=0 to ncnt - 1 do
+          VarClear(newrow[j]);
+        FreeMem(newrow);
+      end;
+    end;
+    newrows.Free;
   end;
 end;
 
@@ -227,18 +268,20 @@ end;
 destructor TVarList.Destroy;
 begin
   FOnDataChanged:=nil;
+  Clear;
   inherited Destroy;
 end;
 
 procedure TVarList.Clear;
 var
-  i: integer;
+  i, j: integer;
   v: PVariant;
 begin
   for i:=0 to Count - 1 do begin
     v:=inherited Get(i);
     if v <> nil then begin
-      VarClear(v^);
+      for j:=0 to ColCnt + IntCols - 1 do
+        VarClear(v[j]);
       FreeMem(v);
     end;
   end;


### PR DESCRIPTION
Build trcomp.lpk before transgui.lpi in the Unix build script so cold ARM containers do not make lazbuild infer package state during the project build. Clean the isolated Lazarus pcp and fail fast so any remaining EAccessViolation stays visible.

Keep TVarList variant row ownership explicit when resizing, clearing, and destroying rows. Initialize TVarGrid cell attributes before early exits, and disconnect item-change callbacks before grid teardown.

On master, fixed-count cold Docker loops passed 100/100 on x86_64 and i686, but reproduced EAccessViolation on ARM: 3/100 on armv6l and 2/100 on armv7l. With this change, armv6l and armv7l each passed 100/100 without retry; final local build, shellcheck, variant smoke, and diff check also passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Lazarus ARM builds and hardens variant row memory handling to stop EAccessViolation crashes. Cold Docker loops now pass 100/100 on `armv6l`/`armv7l`; x86_64 and i686 remain stable.

- **Bug Fixes**
  - Unix build: build `trcomp.lpk` before `transgui.lpi`; use an arch‑scoped per‑run `--pcp` with trap cleanup; wipe/recreate `units` and `lib` before `lazbuild`; pin `--lazarusdir`.
  - TVarList: validate non‑negative column count; resize by allocating new rows and copying min columns, then swap in and free old rows; pre‑size the temp row list; `Clear` frees all per‑cell variants; `Destroy` calls `Clear`.
  - TVarGrid: initialize cell attributes (including `Text`) before early exits; detach `FItems.OnDataChanged` and free `FItems` in `Destroy`.

<sup>Written for commit 257aa0b4dac1f78d987a0bac2023f1af24bb64b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured grid cells always get deterministic, fully initialized attributes even for out-of-range coordinates.
  * Improved component shutdown by consistently detaching data-change notifications before releasing resources.
  * Reworked list resizing and clearing with stricter validation, reducing the risk of inconsistent variant data and potential leaks.
* **Chores**
  * Improved build reliability by using isolated, architecture-specific build state during packaging with automatic cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->