### PR TITLE
Support GTK2 and GTK3 Linux release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
           set -euo pipefail
           docker_args=(
             -e DEBIAN_FRONTEND=noninteractive
+            -e LCL_WIDGETSET=gtk2
             --rm
             -v "${PWD}:/transgui"
           )
@@ -206,7 +207,7 @@ jobs:
       - name: Print checksums
         run: |
           set -euo pipefail
-          artifact="Release/transgui-${PROG_VER}-${{ matrix.artifact_arch }}-Linux.txz"
+          artifact="Release/transgui-${PROG_VER}-${{ matrix.artifact_arch }}-Linux-gtk2.txz"
           md5sum "$artifact"
           shasum -a 1 "$artifact"
           shasum -a 256 "$artifact"
@@ -214,7 +215,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
-          path: Release/transgui-*-${{ matrix.artifact_arch }}-Linux.txz
+          path: Release/transgui-*-${{ matrix.artifact_arch }}-Linux-gtk2.txz
           if-no-files-found: error
 
       - name: Submit to VirusTotal
@@ -228,7 +229,7 @@ jobs:
             exit 0
           fi
 
-          artifact="Release/transgui-${PROG_VER}-${{ matrix.artifact_arch }}-Linux.txz"
+          artifact="Release/transgui-${PROG_VER}-${{ matrix.artifact_arch }}-Linux-gtk2.txz"
           if ! curl --fail-with-body -F "file=@$artifact" -F "apikey=${VIRUSTOTAL_API_KEY}" https://www.virustotal.com/vtapi/v2/file/scan; then
             echo "VirusTotal submission failed for $artifact; continuing without failing the build." >&2
           fi
@@ -344,10 +345,10 @@ jobs:
         run: |
           set -euo pipefail
           files=(
-            "artifacts/transgui-linux-x86_64/transgui-${PROG_VER}-x86_64-Linux.txz"
-            "artifacts/transgui-linux-i686/transgui-${PROG_VER}-i686-Linux.txz"
-            "artifacts/transgui-linux-armv6l/transgui-${PROG_VER}-armv6l-Linux.txz"
-            "artifacts/transgui-linux-armv7l/transgui-${PROG_VER}-armv7l-Linux.txz"
+            "artifacts/transgui-linux-x86_64/transgui-${PROG_VER}-x86_64-Linux-gtk2.txz"
+            "artifacts/transgui-linux-i686/transgui-${PROG_VER}-i686-Linux-gtk2.txz"
+            "artifacts/transgui-linux-armv6l/transgui-${PROG_VER}-armv6l-Linux-gtk2.txz"
+            "artifacts/transgui-linux-armv7l/transgui-${PROG_VER}-armv7l-Linux-gtk2.txz"
             "artifacts/transgui-macos-dmg/transgui-${PROG_VER}.dmg"
           )
 

--- a/Makefile
+++ b/Makefile
@@ -306,12 +306,15 @@ ifeq ($(LAZARUS_DIR),)
 endif
 $(info Using Lazarus dir: $(LAZARUS_DIR))
 LAZRES=$(LAZARUS_DIR)/tools/lazres$(SRCEXEEXT)
-LCL_WIDGETSET=gtk2
-ifneq ($(findstring $(OS_TARGET),win32,win64),)
-LCL_WIDGETSET=win32
+LCL_WIDGETSET ?= gtk2
+ifeq ($(strip $(LCL_WIDGETSET)),)
+override LCL_WIDGETSET := gtk2
 endif
-ifneq ($(findstring $(OS_TARGET),darwin),)
-LCL_WIDGETSET=cocoa
+ifneq ($(filter $(OS_TARGET),win32 win64),)
+override LCL_WIDGETSET := win32
+endif
+ifneq ($(filter $(OS_TARGET),darwin),)
+override LCL_WIDGETSET := cocoa
 endif
 ifeq ($(DEBUG),)
   COMP_OPT=-O3 -g- -CX -XX -Xs -Scgi -l -vewnhibq

--- a/Makefile.fpc
+++ b/Makefile.fpc
@@ -32,12 +32,15 @@ $(info Using Lazarus dir: $(LAZARUS_DIR))
 LAZRES=$(LAZARUS_DIR)/tools/lazres$(SRCEXEEXT)
 
 # Widgetset
-LCL_WIDGETSET=gtk2
-ifneq ($(findstring $(OS_TARGET),win32,win64),)
-LCL_WIDGETSET=win32
+LCL_WIDGETSET ?= gtk2
+ifeq ($(strip $(LCL_WIDGETSET)),)
+override LCL_WIDGETSET := gtk2
 endif
-ifneq ($(findstring $(OS_TARGET),darwin),)
-LCL_WIDGETSET=cocoa
+ifneq ($(filter $(OS_TARGET),win32 win64),)
+override LCL_WIDGETSET := win32
+endif
+ifneq ($(filter $(OS_TARGET),darwin),)
+override LCL_WIDGETSET := cocoa
 endif
 
 ifeq ($(DEBUG),)

--- a/README.md
+++ b/README.md
@@ -55,22 +55,33 @@ The installers are listed on the GitHub [Releases](https://github.com/transmissi
 There are precompiled program's binaries for i386 and x86_64 Linux architectures.
 
 - Download and extract the release for your architecture.
+- Current Linux release archives use the `gtk2` widgetset suffix.
+- Custom Linux builds can select either `gtk2` or `gtk3`.
 
 Now you can execute the `transgui` binary. *(Change the `transgui` file permissions to executable if needed)*
 
 Additionally, you can create a desktop or menu shortcut to the transgui executable, and run the program using the created shortcut.
 
+The Linux archives are GTK-specific, not a promise of one universal Linux binary. If a Linux build does not start, include this diagnostic output in bug reports:
+
+```sh
+ldd ./transgui | grep -E 'gtk|gdk|pango|cairo|fontconfig|X11|not found'
+objdump -T ./transgui | grep -o 'GLIBC_[0-9.]*' | sort -Vu | tail -1
+```
+
 #### Harder way
 
 Build the program by yourself.
+The examples below explicitly select `gtk3` for modern Linux desktops. To build the GTK2 variant, use `--ws=gtk2` and `make LCL_WIDGETSET=gtk2`, or omit both because GTK2 remains the default.
 
 1. Make sure you have working Lazarus and Free Pascal compiler installed.
   - Free Pascal Compiler 2.6.2+ and Lazarus 1.6 is used to develop Transmission Remote GUI.
 2. Download the sources archive and extract it to some folder or perform svn checkout.
 3. Open terminal/command line prompt and cd to the sources folder.
-4. Execute `lazbuild -B "transgui.lpi" --lazarusdir=/usr/lib/lazarus/default/` command to build the transgui.res file.
-5. Execute `make` command to build the application.
-6. Execute `make zipdist` command to create a release .zip archive in the `Release` sub-folder.
+4. Execute `lazbuild -B "transgui.lpi" --ws=gtk3 --lazarusdir=/usr/lib/lazarus/default/` command to build the transgui.res file.
+5. Execute `make LCL_WIDGETSET=gtk3` command to build the application.
+6. Execute `make LCL_WIDGETSET=gtk3 zipdist` command to create a release .zip archive in the `Release` sub-folder.
+  The legacy `zipdist` archive name does not include the selected GTK widgetset.
 
 ### Windows
 

--- a/setup/unix/build.sh
+++ b/setup/unix/build.sh
@@ -5,34 +5,214 @@ set -ex
 ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../" && pwd)"
 VERSION="$(cat "$ROOT/VERSION.txt")"
 ARCH="$(uname -m)"
-LAZARUS_DIR="/usr/lib/lazarus/default"
+
+lazarus_dir_for_lazbuild() {
+  local lazbuild_path="$1"
+  local real_lazbuild
+  local lazarus_dir
+
+  real_lazbuild="$(readlink -f "$lazbuild_path" 2> /dev/null || realpath "$lazbuild_path")" || return 1
+  [ -n "$real_lazbuild" ] || return 1
+
+  lazarus_dir="$(dirname "$real_lazbuild")"
+  if [ "$(basename "$lazarus_dir")" = "bin" ] && [ -d "$(dirname "$lazarus_dir")/lcl" ]; then
+    lazarus_dir="$(dirname "$lazarus_dir")"
+  fi
+  printf '%s\n' "$lazarus_dir"
+}
+
+LCL_WIDGETSET="${LCL_WIDGETSET:-gtk2}"
+if [ -z "${LAZARUS_DIR:-}" ]; then
+  LAZARUS_DIR="/usr/lib/lazarus/default/"
+  if command -v lazbuild > /dev/null 2>&1; then
+    lazbuild_path="$(command -v lazbuild)"
+    detected_lazarus_dir=""
+    if [ -x "$lazbuild_path" ]; then
+      detected_lazarus_dir="$(lazarus_dir_for_lazbuild "$lazbuild_path" || true)"
+    fi
+    if [ -n "$detected_lazarus_dir" ] && [ -d "$detected_lazarus_dir/lcl" ]; then
+      LAZARUS_DIR="$detected_lazarus_dir"
+    fi
+  fi
+  if [ ! -d "$LAZARUS_DIR/lcl" ]; then
+    for lazarus_dir in /usr/lib/lazarus/default /usr/share/lazarus/default /usr/lib/lazarus/* /usr/share/lazarus/* /usr/lib/lazarus /usr/share/lazarus; do
+      if [ -d "$lazarus_dir/lcl" ]; then
+        LAZARUS_DIR="$lazarus_dir"
+        break
+      fi
+    done
+  fi
+fi
+
+if [ ! -d "$LAZARUS_DIR/lcl" ]; then
+  echo "Lazarus directory not found or missing lcl: $LAZARUS_DIR" >&2
+  exit 8
+fi
+
+LAZBUILD_CMD="lazbuild"
+if [ -x "$LAZARUS_DIR/lazbuild" ]; then
+  LAZBUILD_CMD="$LAZARUS_DIR/lazbuild"
+elif [ -x "$LAZARUS_DIR/bin/lazbuild" ]; then
+  LAZBUILD_CMD="$LAZARUS_DIR/bin/lazbuild"
+else
+  lazbuild_path="$(command -v lazbuild || true)"
+  if [ -z "$lazbuild_path" ] || [ ! -x "$lazbuild_path" ]; then
+    echo "lazbuild not found in $LAZARUS_DIR or PATH" >&2
+    exit 9
+  fi
+  LAZBUILD_CMD="$lazbuild_path"
+fi
+
+lazbuild_dir="$(lazarus_dir_for_lazbuild "$LAZBUILD_CMD")" || {
+  echo "Unable to resolve lazbuild path: $LAZBUILD_CMD" >&2
+  exit 9
+}
+if [ "$(cd "$lazbuild_dir" && pwd -P)" != "$(cd "$LAZARUS_DIR" && pwd -P)" ]; then
+  echo "lazbuild at $LAZBUILD_CMD does not match LAZARUS_DIR: $LAZARUS_DIR" >&2
+  exit 9
+fi
+
+case "$LCL_WIDGETSET" in
+  gtk2 | gtk3) ;;
+  *)
+    echo "Unsupported LCL_WIDGETSET: $LCL_WIDGETSET" >&2
+    echo "Supported values: gtk2, gtk3" >&2
+    exit 3
+    ;;
+esac
+
 LAZARUS_PCP="$(mktemp -d "/tmp/lazarus-pcp-transgui-${ARCH}.XXXXXX")"
-trap 'rm -rf "${LAZARUS_PCP:?}"' EXIT
+
+cleanup() {
+  if [ -n "${about_tmp_file:-}" ] && [ -f "$about_tmp_file" ]; then
+    rm -f "$about_tmp_file"
+  fi
+  if [ "${about_backup_created:-0}" = "1" ] && [ -f "$about_backup_file" ]; then
+    mv "$about_backup_file" "$ROOT/about.lfm"
+  fi
+  if [ -n "${LAZARUS_PCP:-}" ] && [ -d "$LAZARUS_PCP" ]; then
+    rm -rf "${LAZARUS_PCP:?}"
+  fi
+}
+trap cleanup EXIT
 
 cleanup_lazbuild_state() {
   rm -rf "${ROOT:?}/units" "${ROOT:?}/lib"
   mkdir -p "${ROOT:?}/units" "${ROOT:?}/lib" "${LAZARUS_PCP:?}"
 }
 
+has_lcl_widgetset_units() {
+  [ -f "$LAZARUS_DIR/lcl/units/$FPC_FULL_TARGET/$LCL_WIDGETSET/interfaces.ppu" ]
+}
+
+prepare_lcl_widgetset() {
+  if has_lcl_widgetset_units; then
+    return
+  fi
+
+  if [ ! -d "$LAZARUS_DIR/lcl/interfaces/$LCL_WIDGETSET" ]; then
+    echo "Lazarus LCL widgetset interface sources not found: $LCL_WIDGETSET" >&2
+    exit 10
+  fi
+
+  make -C "$LAZARUS_DIR/lcl/interfaces/$LCL_WIDGETSET" -j"$NPROC" all
+
+  if ! has_lcl_widgetset_units; then
+    echo "Failed to build Lazarus LCL widgetset units: $LCL_WIDGETSET" >&2
+    exit 10
+  fi
+}
+
 run_lazbuild() {
   cleanup_lazbuild_state
-  lazbuild -B "$ROOT/trcomp.lpk" --lazarusdir="$LAZARUS_DIR" --pcp="$LAZARUS_PCP"
-  lazbuild -B "$ROOT/transgui.lpi" --lazarusdir="$LAZARUS_DIR" --pcp="$LAZARUS_PCP"
+  "$LAZBUILD_CMD" -B "$ROOT/trcomp.lpk" \
+    --ws="$LCL_WIDGETSET" \
+    --lazarusdir="$LAZARUS_DIR" \
+    --pcp="$LAZARUS_PCP"
+  "$LAZBUILD_CMD" -B "$ROOT/transgui.lpi" \
+    --ws="$LCL_WIDGETSET" \
+    --lazarusdir="$LAZARUS_DIR" \
+    --pcp="$LAZARUS_PCP"
 }
 
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD)"
-lazarus_ver="$(lazbuild -v)"
-fpc_ver="$(fpc -i V | head -n 1)"
+lazarus_ver="$("$LAZBUILD_CMD" -v)"
+fpc_ver="Free Pascal Compiler version $(fpc -iV)"
+FPC_FULL_TARGET="$(fpc -iTP)-$(fpc -iTO)"
+about_file="$ROOT/about.lfm"
+version_caption="Caption = 'Version %s'"
+build_caption="Caption = 'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver, LCL $LCL_WIDGETSET'"
+about_backup_created=0
+about_backup_file=""
+about_tmp_file=""
 
-sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" "$ROOT/about.lfm"
+if ! grep -Fq "$version_caption" "$about_file"; then
+  echo "Unable to find version caption in $about_file" >&2
+  exit 4
+fi
 
+about_backup_file="$(mktemp "$about_file.bak.XXXXXX")"
+cp -p "$about_file" "$about_backup_file"
+about_backup_created=1
+about_tmp_file="$(mktemp "$about_file.XXXXXX")"
+awk -v old="$version_caption" -v new="$build_caption" '
+  index($0, "object txVersion: TLabel") {
+    in_tx_version = 1
+  }
+  in_tx_version && !done {
+    pos = index($0, old)
+    if (pos) {
+      $0 = substr($0, 1, pos - 1) new substr($0, pos + length(old))
+      done = 1
+    }
+  }
+  in_tx_version && /^[[:space:]]*end[[:space:]]*$/ {
+    in_tx_version = 0
+  }
+  { print }
+  END {
+    if (!done) {
+      exit 1
+    }
+  }
+' "$about_backup_file" > "$about_tmp_file"
+mv "$about_tmp_file" "$about_file"
+about_tmp_file=""
+
+if ! awk -v needle="LCL $LCL_WIDGETSET" '
+  index($0, "object txVersion: TLabel") {
+    in_tx_version = 1
+  }
+  in_tx_version && index($0, needle) {
+    found = 1
+  }
+  in_tx_version && /^[[:space:]]*end[[:space:]]*$/ {
+    in_tx_version = 0
+  }
+  END {
+    exit found ? 0 : 1
+  }
+' "$about_file"; then
+  echo "Failed to inject build metadata into $about_file" >&2
+  exit 5
+fi
+
+NPROC="$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || getconf _NPROCESSORS_ONLN 2> /dev/null || echo 1)"
+
+prepare_lcl_widgetset
 run_lazbuild
-make -C "$ROOT" -j"$(nproc)" clean
-make -C "$ROOT" -j"$(nproc)" all
 
-mv "$ROOT/about.lfm.bak" "$ROOT/about.lfm"
+make -C "$ROOT" -j"$NPROC" clean \
+  LAZARUS_DIR="$LAZARUS_DIR" \
+  LCL_WIDGETSET="$LCL_WIDGETSET"
+
+make -C "$ROOT" -j"$NPROC" all \
+  LAZARUS_DIR="$LAZARUS_DIR" \
+  LCL_WIDGETSET="$LCL_WIDGETSET"
+
+bash "$ROOT/setup/unix/verify_linux_binary.sh" "$ROOT/transgui" "$LCL_WIDGETSET"
 
 cd "$ROOT" || exit 1
 mkdir -p Release/
-FILENAME="transgui-${VERSION}-$(uname -m)-$(uname).txz"
+FILENAME="transgui-${VERSION}-$(uname -m)-$(uname)-${LCL_WIDGETSET}.txz"
 XZ_OPT=-9 tar cJf "Release/$FILENAME" transgui README.md history.txt LICENSE transgui.png lang

--- a/setup/unix/debian-ubuntu-install_deps.sh
+++ b/setup/unix/debian-ubuntu-install_deps.sh
@@ -2,5 +2,57 @@
 
 set -ex
 
+LCL_WIDGETSET="${LCL_WIDGETSET:-gtk2}"
+
+base_pkgs=(
+  lazarus
+  fpc
+  xz-utils
+  coreutils
+  git
+  make
+  jq
+  zip
+  binutils
+  pkg-config
+  libssl-dev
+)
+
+case "$LCL_WIDGETSET" in
+  gtk2)
+    widget_pkgs=(libgtk2.0-dev)
+    ;;
+  gtk3)
+    widget_pkgs=(libgtk-3-dev)
+    ;;
+  *)
+    echo "Unsupported LCL_WIDGETSET: $LCL_WIDGETSET" >&2
+    echo "Supported values: gtk2, gtk3" >&2
+    exit 2
+    ;;
+esac
+
 apt update -yqq
-apt install -yqq --no-install-recommends lazarus fpc xz-utils coreutils git make jq zip libssl-dev
+apt install -yqq --no-install-recommends \
+  "${base_pkgs[@]}" \
+  "${widget_pkgs[@]}"
+
+for lazarus_dir in /usr/lib/lazarus /usr/share/lazarus; do
+  if [ -d "$lazarus_dir" ]; then
+    if find "$lazarus_dir" -type d -path "*/lcl/units/*/${LCL_WIDGETSET}" -print -quit | grep -q .; then
+      exit 0
+    fi
+
+    interface_dir="$(find "$lazarus_dir" -type d -path "*/lcl/interfaces/${LCL_WIDGETSET}" -print -quit || true)"
+    if [ -n "$interface_dir" ] &&
+      find "$interface_dir" -type f \( -name '*.pas' -o -name '*.pp' \) -print -quit | grep -q .; then
+      echo "Prebuilt Lazarus LCL widgetset units not found: ${LCL_WIDGETSET}" >&2
+      echo "Lazarus sources are available; build.sh will compile them during build." >&2
+      exit 0
+    fi
+  fi
+done
+
+echo "Lazarus LCL widgetset units not found: ${LCL_WIDGETSET}" >&2
+echo "Please ensure the Lazarus package for ${LCL_WIDGETSET} is installed." >&2
+exit 3

--- a/setup/unix/use-buster-archive-apt.sh
+++ b/setup/unix/use-buster-archive-apt.sh
@@ -4,7 +4,9 @@ set -ex
 
 case "${1-}" in
   debian)
-    printf '%s\n' 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+    printf '%s\n' \
+      'Acquire::Check-Valid-Until "false";' \
+      'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99archive
     for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
       [ -f "$source_file" ] || continue
       sed -i \
@@ -15,7 +17,9 @@ case "${1-}" in
     done
     ;;
   raspbian)
-    printf '%s\n' 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+    printf '%s\n' \
+      'Acquire::Check-Valid-Until "false";' \
+      'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99archive
     for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
       [ -f "$source_file" ] || continue
       sed -i \

--- a/setup/unix/verify_linux_binary.sh
+++ b/setup/unix/verify_linux_binary.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -e
+
+binary="${1:-./transgui}"
+expected_widgetset="${2:-${LCL_WIDGETSET:-gtk2}}"
+
+if [ ! -x "$binary" ]; then
+  echo "Binary not found or not executable: $binary" >&2
+  exit 2
+fi
+
+if ! command -v readelf > /dev/null 2>&1; then
+  echo "readelf not found; install binutils to inspect shared libraries." >&2
+  exit 3
+fi
+
+needed_libs="$(
+  readelf -d "$binary" |
+    awk '/\(NEEDED\)/ {
+      sub(/^.*\[/, "")
+      sub(/\].*$/, "")
+      print
+    }'
+)"
+
+if [ -z "$needed_libs" ]; then
+  echo "Unable to inspect shared libraries for: $binary" >&2
+  exit 4
+fi
+
+echo "Declared GTK/GDK linkage:"
+grep -E 'gtk|gdk|pango|cairo|fontconfig|X11' <<< "$needed_libs" || true
+
+if [ "${VERIFY_LINUX_RUNTIME_LIBS:-0}" = "1" ]; then
+  if command -v ldd > /dev/null 2>&1; then
+    ldd_status=0
+    ldd_output="$(ldd "$binary" 2>&1)" || ldd_status=$?
+    missing="$(awk '/=> not found/ {print $1}' <<< "$ldd_output")"
+
+    if [ -n "$missing" ]; then
+      echo "Missing shared libraries:" >&2
+      echo "$missing" >&2
+
+      case "$expected_widgetset" in
+        gtk2)
+          echo "For Debian/Ubuntu GTK2 runtime, try: sudo apt install libgtk2.0-0" >&2
+          ;;
+        gtk3)
+          echo "For Debian/Ubuntu GTK3 runtime, try: sudo apt install libgtk-3-0" >&2
+          ;;
+      esac
+
+      exit 4
+    fi
+
+    if [ "$ldd_status" -ne 0 ]; then
+      echo "ldd could not inspect runtime libraries; continuing with ELF linkage data." >&2
+      echo "$ldd_output" >&2
+    fi
+  else
+    echo "ldd not found; skipping runtime missing-library check." >&2
+  fi
+else
+  echo "Runtime missing-library check disabled; set VERIFY_LINUX_RUNTIME_LIBS=1 for trusted builds." >&2
+fi
+
+case "$expected_widgetset" in
+  gtk2)
+    if ! grep -Fq 'libgtk-x11-2.0.so.0' <<< "$needed_libs"; then
+      echo "Expected GTK2 linkage, but libgtk-x11-2.0.so.0 was not found." >&2
+      exit 5
+    fi
+    if grep -Fq 'libgtk-3.so.0' <<< "$needed_libs"; then
+      echo "Expected GTK2 linkage, but GTK3 linkage was also found." >&2
+      exit 5
+    fi
+    ;;
+  gtk3)
+    if ! grep -Fq 'libgtk-3.so.0' <<< "$needed_libs"; then
+      echo "Expected GTK3 linkage, but libgtk-3.so.0 was not found." >&2
+      exit 6
+    fi
+    if grep -Fq 'libgtk-x11-2.0.so.0' <<< "$needed_libs"; then
+      echo "Expected GTK3 linkage, but GTK2 linkage was also found." >&2
+      exit 6
+    fi
+    ;;
+  none)
+    echo "No expected widgetset enforcement requested; linkage check only."
+    ;;
+  *)
+    echo "Unsupported expected widgetset: $expected_widgetset" >&2
+    exit 7
+    ;;
+esac
+
+if command -v objdump > /dev/null 2>&1; then
+  echo "Highest GLIBC requirement:"
+  objdump -T "$binary" |
+    grep -o 'GLIBC_[0-9][0-9.]*' |
+    awk '
+      function version_gt(a, b,    av, bv, i, n) {
+        n = split(a, av, ".")
+        split(b, bv, ".")
+        for (i = 1; i <= n || i in bv; i++) {
+          if ((av[i] + 0) > (bv[i] + 0)) return 1
+          if ((av[i] + 0) < (bv[i] + 0)) return 0
+        }
+        return 0
+      }
+      {
+        version = substr($0, 7)
+        if (max_version == "" || version_gt(version, max_version)) {
+          max_version = version
+        }
+      }
+      END {
+        if (max_version != "") print "GLIBC_" max_version
+      }
+    ' || true
+else
+  echo "objdump not found; install binutils to inspect GLIBC requirements." >&2
+fi
+
+echo "Binary verification passed."


### PR DESCRIPTION
Allow Linux release builds to select gtk2 or gtk3 explicitly while keeping gtk2 as the default fallback. Pass the widgetset through both lazbuild and make so the two build steps cannot diverge, and verify the produced binary links against the expected GTK runtime before packaging.

Update the Debian/Ubuntu dependency helper, documentation, and Linux CI artifact names to match the new gtk-suffixed archive names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit Linux release builds for `gtk2` and `gtk3` (default `gtk2`), propagate the widgetset to `lazbuild` and `make`, verify GTK linkage from ELF by default, and suffix Linux artifacts by GTK variant. CI, docs, and build tooling were updated; `LAZARUS_DIR` auto-detection is stricter, missing LCL units are built, and the About dialog shows the widgetset.

- **New Features**
  - Select widgetset via `LCL_WIDGETSET=gtk2|gtk3` (default `gtk2`); passed to `lazbuild --ws` and `make` (Makefiles use `?=`; Windows/Cocoa override).
  - New `setup/unix/verify_linux_binary.sh` validates GTK linkage via ELF and prints max `GLIBC`; optional runtime check with `VERIFY_LINUX_RUNTIME_LIBS=1`.
  - Auto-detect `LAZARUS_DIR` from `lazbuild`, ensure it matches, support `/usr/lib/lazarus` or `/usr/share/lazarus`; build missing LCL widgetset units when not prebuilt.
  - Build injects LCL widgetset into About; portable CPU count; Debian/Ubuntu helper installs `libgtk2.0-dev` or `libgtk-3-dev`.
  - CI builds Linux with `LCL_WIDGETSET=gtk2` and publishes `-gtk2` artifacts; docs note GTK-specific archives and add diagnostic commands; Debian/Raspbian apt retries reduce flakiness.

- **Migration**
  - Linux archives are suffixed `-gtk2` or `-gtk3` (e.g., `transgui-<ver>-<arch>-Linux-gtk2.txz`); update any consumers.
  - To build `gtk3`: `lazbuild ... --ws=gtk3` and `make LCL_WIDGETSET=gtk3`. The legacy `zipdist` archive name is unchanged.

<sup>Written for commit cda33bf44393b4f755ee2bdc23ba5b7c1f224dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux CI and release artifacts now use GTK2-specific archive naming for the prebuilt widgetset.
* **Bug Fixes**
  * Builds preserve a user-provided widgetset selection (GTK2 defaults only when unset), including for Makefile variants and packaging output naming.
  * Added stronger Linux ELF/binary verification with widgetset-aware dependency checks and clearer error output.
* **Documentation**
  * Expanded Linux install/build instructions to cover GTK2 vs GTK3, plus improved troubleshooting commands.
* **Chores**
  * Improved Debian/Raspberry Pi apt archive retry configuration for more reliable downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->