### PR TITLE
Fix UI alignment in options, daemon & connection dialogs

### DIFF
--- a/connoptions.lfm
+++ b/connoptions.lfm
@@ -66,7 +66,7 @@ inherited ConnOptionsForm: TConnOptionsForm
       object edPassword: TEdit
         Left = 180
         Height = 23
-        Top = 153
+        Top = 154
         Width = 316
         Anchors = [akTop, akLeft, akRight]
         EchoMode = emPassword

--- a/daemonoptions.lfm
+++ b/daemonoptions.lfm
@@ -109,7 +109,7 @@ inherited DaemonOptionsForm: TDaemonOptionsForm
       object edSeedRatio: TFloatSpinEdit
         Left = 431
         Height = 21
-        Top = 134
+        Top = 132
         Width = 66
         Anchors = [akTop, akRight]
         Increment = 0.1
@@ -345,7 +345,7 @@ inherited DaemonOptionsForm: TDaemonOptionsForm
         object edMaxUp: TSpinEdit
           Left = 455
           Height = 21
-          Top = 28
+          Top = 29
           Width = 66
           Anchors = [akTop, akRight]
           Increment = 10
@@ -416,7 +416,7 @@ inherited DaemonOptionsForm: TDaemonOptionsForm
         object txTo: TLabel
           Left = 150
           Height = 14
-          Top = 104
+          Top = 103
           Width = 49
           Alignment = taCenter
           AutoSize = False
@@ -436,7 +436,7 @@ inherited DaemonOptionsForm: TDaemonOptionsForm
         object edAltUp: TSpinEdit
           Left = 455
           Height = 21
-          Top = 28
+          Top = 29
           Width = 66
           Anchors = [akTop, akRight]
           Increment = 10

--- a/options.lfm
+++ b/options.lfm
@@ -298,7 +298,7 @@ inherited OptionsForm: TOptionsForm
       object cbLangLeftRight: TComboBox
         Left = 392
         Height = 23
-        Top = 148
+        Top = 146
         Width = 136
         Anchors = [akTop, akLeft, akRight]
         DropDownCount = 60


### PR DESCRIPTION
Align misaligned controls in three dialogs:

- options.lfm: language and text-direction dropdowns share Top=146
- daemonoptions.lfm: seed-ratio spin, alt-speed From/To labels, upload speed spins
- connoptions.lfm: password edit relative to its label

Pure .lfm layout tweaks; no logic or strings changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align UI controls in the Options, Daemon, and Connection dialogs for consistent vertical spacing. UI-only .lfm tweaks; no logic or strings changed.

- **Bug Fixes**
  - options.lfm: Align language and text-direction dropdowns at Top=146.
  - daemonoptions.lfm: Seed ratio Top=132; "To" label Top=103; upload/alt-upload speed inputs Top=29.
  - connoptions.lfm: Password field aligned with its label at Top=154.

<sup>Written for commit 3873bdcc637a69a4b5ebec9ef7944433d0844623. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted spacing and alignment in several options dialogs for a cleaner, more consistent layout.
  * Fine-tuned the position of a language selector and multiple transmission-related controls to improve visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->