### PR TITLE
Prevent hangs on close while waiting for a remote daemon

### DIFF
--- a/rpc.pas
+++ b/rpc.pas
@@ -81,6 +81,7 @@ type
     procedure DoFillSessionInfo;
     procedure NotifyCheckStatus;
     procedure CheckStatusHandler(Data: PtrInt);
+    function IsTerminated: boolean;
   protected
     procedure Execute; override;
   public
@@ -114,6 +115,9 @@ type
     procedure SetStatus(const AValue: string);
     procedure SetTorrentFields(const AValue: string);
     procedure CreateHttp;
+    procedure HttpHeartbeat(Sender: TObject);
+    procedure HttpSocketCreated(Sender: TObject);
+    procedure StopRpcThread;
   public
     Http: THTTPSend;
     HttpLock: TCriticalSection;
@@ -251,13 +255,10 @@ begin
     end;
   except
     Status:=Exception(ExceptObject).Message;
-    FRpc.RpcThread:=nil;
     NotifyCheckStatus;
   end;
-  FRpc.RpcThread:=nil;
   FRpc.FConnected:=False;
   FRpc.FRPCVersion:=0;
-  Sleep(20);
 end;
 
 constructor TRpcThread.Create;
@@ -267,7 +268,13 @@ end;
 
 destructor TRpcThread.Destroy;
 begin
+  Application.RemoveAsyncCalls(Self);
   inherited Destroy;
+end;
+
+function TRpcThread.IsTerminated: boolean;
+begin
+  Result:=Terminated;
 end;
 
 procedure TRpcThread.SetStatus(const AValue: string);
@@ -607,6 +614,7 @@ end;
 
 destructor TRpc.Destroy;
 begin
+  Disconnect;
   Http.Free;
   HttpLock.Free;
   FLock.Free;
@@ -707,7 +715,7 @@ var
   res: TJSONObject;
   jp: TJSONParser;
   s: string;
-  i, j, OldTimeOut, RetryCnt: integer;
+  i, j, OldTimeOut, OldDataTimeOut, OldNonblockSendTimeOut, RetryCnt: integer;
   locked, r: boolean;
 begin
   if FRpcPath = '' then
@@ -722,6 +730,8 @@ begin
     locked:=True;
     try
       OldTimeOut:=Http.Timeout;
+      OldDataTimeOut:=Http.Sock.SSL.DataTimeout;
+      OldNonblockSendTimeOut:=Http.Sock.NonblockSendTimeout;
       RequestStartTime:=Now;
       Http.Document.Clear;
       s:=req.AsJSON;
@@ -732,17 +742,25 @@ begin
       Http.MimeType:='application/json';
       if XTorrentSession <> '' then
         Http.Headers.Add(XTorrentSession);
-      if ATimeOut >= 0 then
+      if ATimeOut >= 0 then begin
         Http.Timeout:=ATimeOut;
+        Http.Sock.SSL.DataTimeout:=ATimeOut;
+        Http.Sock.NonblockSendTimeout:=ATimeOut;
+      end;
       try
         r:=Http.HTTPMethod('POST', Url + FRpcPath);
       finally
         Http.Timeout:=OldTimeOut;
+        Http.Sock.SSL.DataTimeout:=OldDataTimeOut;
+        Http.Sock.NonblockSendTimeout:=OldNonblockSendTimeOut;
       end;
       if not r then begin
         if FMainThreadId <> GetCurrentThreadId then
           ReconnectAllowed:=True;
         Status:=Http.Sock.LastErrorDesc;
+        if not (Http.Sock.SSL is TSSLNone) then
+          Http.Sock.SSL.Shutdown;
+        Http.Sock.AbortSocket;
         break;
       end
       else begin
@@ -983,7 +1001,7 @@ end;
 
 function TRpc.GetConnecting: boolean;
 begin
-  Result:=not FConnected and Assigned(RpcThread);
+  Result:=not FConnected and Assigned(RpcThread) and not RpcThread.Finished;
 end;
 
 function TRpc.GetInfoStatus: string;
@@ -1026,18 +1044,40 @@ begin
   Http.Free;
   Http:=THTTPSend.Create;
   Http.Protocol:='1.1';
+  // Let Abort interrupt blocking socket waits during disconnect.
+  Http.Sock.HeartbeatRate:=250;
+  Http.Sock.OnHeartbeat:=@HttpHeartbeat;
+  Http.Sock.OnCreateSocket:=@HttpSocketCreated;
 
   i := Ini.ReadInteger('NetWork', 'HttpTimeout', 30);
   if (i < 2) or (i > 999) then i:= 30; // default
   Ini.WriteInteger('NetWork', 'HttpTimeout', i);
   Http.Timeout:= i * 1000;
+  Http.Sock.SSL.DataTimeout:=Http.Timeout;
+  Http.Sock.NonblockSendTimeout:=Http.Timeout;
 
   i := Ini.ReadInteger('NetWork', 'ConnectTimeout', 0);
   if (i < 0) or (i > 999) then i:= 0; // default
   Ini.WriteInteger('NetWork', 'ConnectTimeout', i);
-  Http.FSock.ConnectionTimeout := i * 1000;
+  // A positive timeout makes TCP and TLS handshakes cancellable.
+  if i = 0 then
+    Http.FSock.ConnectionTimeout:=Http.Timeout
+  else
+    Http.FSock.ConnectionTimeout:=i * 1000;
 
   Http.Headers.NameValueSeparator:=':';
+end;
+
+procedure TRpc.HttpHeartbeat(Sender: TObject);
+begin
+  if Assigned(RpcThread) and (RpcThread.ThreadID = GetCurrentThreadId) and
+     RpcThread.IsTerminated then
+    TBlockSocket(Sender).StopFlag:=True;
+end;
+
+procedure TRpc.HttpSocketCreated(Sender: TObject);
+begin
+  TBlockSocket(Sender).NonBlockMode:=True;
 end;
 
 procedure TRpc.Lock;
@@ -1050,8 +1090,23 @@ begin
   FLock.Leave;
 end;
 
+procedure TRpc.StopRpcThread;
+begin
+  if Assigned(RpcThread) then begin
+    RpcThread.Terminate;
+    Http.Abort;
+    RpcThread.WaitFor;
+    if not (Http.Sock.SSL is TSSLNone) then
+      Http.Sock.SSL.Shutdown;
+    Http.Sock.AbortSocket;
+    Http.Sock.StopFlag:=False;
+    FreeAndNil(RpcThread);
+  end;
+end;
+
 procedure TRpc.Connect;
 begin
+  StopRpcThread;
   CurTorrentId:=0;
   XTorrentSession:='';
   RequestFullInfo:=True;
@@ -1059,7 +1114,7 @@ begin
   RefreshNow:=[];
   RpcThread:=TRpcThread.Create;
   with RpcThread do begin
-    FreeOnTerminate:=True;
+    FreeOnTerminate:=False;
     FRpc:=Self;
     Suspended:=False;
   end;
@@ -1067,21 +1122,10 @@ end;
 
 procedure TRpc.Disconnect;
 begin
-  if Assigned(RpcThread) then begin
-    RpcThread.Terminate;
-    while Assigned(RpcThread) do begin
-      Application.ProcessMessages;
-      try
-        Http.Sock.CloseSocket;
-      except
-      end;
-      Sleep(20);
-    end;
-  end;
+  StopRpcThread;
   Status:='';
   RequestStartTime:=0;
   FRpcPath:='';
 end;
 
 end.
-

--- a/synapse/source/lib/blcksock.pas
+++ b/synapse/source/lib/blcksock.pas
@@ -321,6 +321,7 @@ type
     procedure SetSizeRecvBuffer(Size: Integer);
     function GetSizeSendBuffer: Integer;
     procedure SetSizeSendBuffer(Size: Integer);
+    function GetSocketError: Integer;
     procedure SetNonBlockMode(Value: Boolean);
     procedure SetTTL(TTL: integer);
     function GetTTL:integer;
@@ -1240,6 +1241,7 @@ type
     FSSHChannelArg2: string;
     FCertComplianceLevel: integer;
     FSNIHost: string;
+    FDataTimeout: integer;
     procedure ReturnError;
     procedure SetCertCAFile(const Value: string); virtual;
     function DoVerifyCert:boolean;
@@ -1433,6 +1435,10 @@ type
        The value is cleared after the connection is established.
       (SNI support requires OpenSSL 0.9.8k or later. Cryptlib not supported, yet )  }
     property SNIHost:string read FSNIHost write FSNIHost;
+
+    {:Timeout for SSL/TLS application data operations. A negative value preserves
+      the plugin default behavior.}
+    property DataTimeout: integer read FDataTimeout write FDataTimeout;
   end;
 
   {:@abstract(Default SSL plugin with no SSL support.)
@@ -1921,6 +1927,7 @@ procedure TBlockSocket.Connect(IP, Port: string);
 var
   Sin: TVarSin;
   b: boolean;
+  x: integer;
 begin
   SetSin(Sin, IP, Port);
   if FLastError = 0 then
@@ -1932,11 +1939,24 @@ begin
       // connect in non-blocking mode
       b := NonBlockMode;
       NonBlockMode := true;
-      SockCheck(synsock.Connect(FSocket, Sin));
-      if (FLastError = WSAEINPROGRESS) OR (FLastError = WSAEWOULDBLOCK) then
-        if not CanWrite(FConnectionTimeout) then
-          FLastError := WSAETIMEDOUT;
-      NonBlockMode := b;
+      try
+        SockCheck(synsock.Connect(FSocket, Sin));
+        if (FLastError = WSAEINPROGRESS) OR (FLastError = WSAEWOULDBLOCK) then
+          if not CanWrite(FConnectionTimeout) then
+          begin
+            if (FLastError = 0) or (FLastError = WSAEINPROGRESS) or
+               (FLastError = WSAEWOULDBLOCK) then
+              FLastError := WSAETIMEDOUT;
+          end
+          else
+          begin
+            x := GetSocketError;
+            FLastError := x;
+            FLastErrorDesc := GetErrorDescEx;
+          end;
+      finally
+        NonBlockMode := b;
+      end;
     end
     else
       SockCheck(synsock.Connect(FSocket, Sin));
@@ -2066,7 +2086,8 @@ begin
           SockCheck(r);
         end
         else
-          FLastError := WSAETIMEDOUT;
+          if FLastError = 0 then
+            FLastError := WSAETIMEDOUT;
       end;
       if FLastError <> 0 then
         Break;
@@ -2364,7 +2385,8 @@ begin
         end;
       end
       else
-        FLastError := WSAETIMEDOUT;
+        if FLastError = 0 then
+          FLastError := WSAETIMEDOUT;
     end;
   end;
   if FConvertLineEnd and (Result <> '') then
@@ -2770,7 +2792,7 @@ var
   ti, tr: Integer;
   n: integer;
 begin
-  if (FHeartbeatRate <> 0) and (Timeout <> -1) then
+  if (FHeartbeatRate <> 0) and (Timeout > 0) then
   begin
     ti := Timeout div FHeartbeatRate;
     tr := Timeout mod FHeartbeatRate;
@@ -2781,20 +2803,26 @@ begin
     tr := Timeout;
   end;
   Result := InternalCanRead(tr);
-  if not Result then
-    for n := 0 to ti do
+  if not Result and (Timeout <> 0) then
+    for n := 1 to ti do
     begin
       DoHeartbeat;
       if FStopFlag then
       begin
         Result := False;
         FStopFlag := False;
+        FLastError := WSAECONNABORTED;
         Break;
       end;
       Result := InternalCanRead(FHeartbeatRate);
       if Result then
         break;
     end;
+  if not Result and FStopFlag then
+  begin
+    FStopFlag := False;
+    FLastError := WSAECONNABORTED;
+  end;
   ExceptCheck;
   if Result then
     DoStatus(HR_CanRead, '');
@@ -2830,7 +2858,7 @@ var
   ti, tr: Integer;
   n: integer;
 begin
-  if (FHeartbeatRate <> 0) and (Timeout <> -1) then
+  if (FHeartbeatRate <> 0) and (Timeout > 0) then
   begin
     ti := Timeout div FHeartbeatRate;
     tr := Timeout mod FHeartbeatRate;
@@ -2841,20 +2869,26 @@ begin
     tr := Timeout;
   end;
   Result := InternalCanWrite(tr);
-  if not Result then
-    for n := 0 to ti do
+  if not Result and (Timeout <> 0) then
+    for n := 1 to ti do
     begin
       DoHeartbeat;
       if FStopFlag then
       begin
         Result := False;
         FStopFlag := False;
+        FLastError := WSAECONNABORTED;
         Break;
       end;
       Result := InternalCanWrite(FHeartbeatRate);
       if Result then
         break;
     end;
+  if not Result and FStopFlag then
+  begin
+    FStopFlag := False;
+    FLastError := WSAECONNABORTED;
+  end;
   ExceptCheck;
   if Result then
     DoStatus(HR_CanWrite, '');
@@ -2954,6 +2988,33 @@ begin
   d.Option := SOT_SendBuff;
   d.Value := Size;
   DelayedOption(d);
+end;
+
+function TBlockSocket.GetSocketError: Integer;
+var
+  l: Integer;
+{$IFDEF CIL}
+  buf: TMemory;
+{$ENDIF}
+begin
+  Result := 0;
+  l := SizeOf(Result);
+{$IFDEF CIL}
+  SetLength(buf, l);
+  if synsock.GetSockOpt(FSocket, integer(SOL_SOCKET), integer(SO_ERROR), buf, l) = SOCKET_ERROR then
+  begin
+    SockCheck(SOCKET_ERROR);
+    Result := FLastError;
+  end
+  else
+    Result := System.BitConverter.ToInt32(buf, 0);
+{$ELSE}
+  if synsock.GetSockOpt(FSocket, SOL_SOCKET, SO_ERROR, @Result, l) = SOCKET_ERROR then
+  begin
+    SockCheck(SOCKET_ERROR);
+    Result := FLastError;
+  end;
+{$ENDIF}
 end;
 
 procedure TBlockSocket.SetNonBlockMode(Value: Boolean);
@@ -4184,6 +4245,7 @@ begin
   FSSHChannelArg2 := '';
   FCertComplianceLevel := -1; //default
   FSNIHost := '';
+  FDataTimeout := -1;
 end;
 
 procedure TCustomSSL.Assign(const Value: TCustomSSL);
@@ -4206,6 +4268,7 @@ begin
   FPFXfile := Value.PFXfile;
   FCertComplianceLevel := Value.CertComplianceLevel;
   FSNIHost := Value.FSNIHost;
+  FDataTimeout := Value.DataTimeout;
 end;
 
 procedure TCustomSSL.ReturnError;

--- a/synapse/source/lib/ssl_openssl.pas
+++ b/synapse/source/lib/ssl_openssl.pas
@@ -111,6 +111,8 @@ type
     function Init(server:Boolean): Boolean;
     function DeInit: Boolean;
     function Prepare(server:Boolean): Boolean;
+    procedure SetWaitError;
+    function WaitForIO(Error: integer; StartTick: LongWord): Boolean;
     function LoadPFX(pfxdata: ansistring): Boolean;
     function CreateSelfSignedCert(Host: string): Boolean; override;
   public
@@ -502,6 +504,36 @@ begin
     DeInit;
 end;
 
+procedure TSSLOpenSSL.SetWaitError;
+begin
+  if FSocket.LastError <> 0 then
+  begin
+    FLastError:=FSocket.LastError;
+    FLastErrorDesc:=FSocket.LastErrorDesc;
+  end
+  else
+  begin
+    FLastError:=WSAETIMEDOUT;
+    FLastErrorDesc:=TBlockSocket.GetErrorDesc(WSAETIMEDOUT);
+  end;
+end;
+
+function TSSLOpenSSL.WaitForIO(Error: integer; StartTick: LongWord): Boolean;
+var
+  Timeout: integer;
+begin
+  Timeout:=DataTimeout - integer(TickDelta(StartTick, GetTick));
+  if Timeout >= 0 then
+    if Error = SSL_ERROR_WANT_READ then
+      Result:=FSocket.CanRead(Timeout)
+    else
+      Result:=FSocket.CanWrite(Timeout)
+  else
+    Result:=False;
+  if not Result then
+    SetWaitError;
+end;
+
 function TSSLOpenSSL.Connect: boolean;
 var
   x: integer;
@@ -537,17 +569,33 @@ begin
     begin
       b := Fsocket.NonBlockMode;
       Fsocket.NonBlockMode := true;
-      repeat
-        x := sslconnect(FSsl);
-        err := SslGetError(FSsl, x);
-        if err = SSL_ERROR_WANT_READ then
-          if not FSocket.CanRead(FSocket.ConnectionTimeout) then
-            break;
-        if err = SSL_ERROR_WANT_WRITE then
-          if not FSocket.CanWrite(FSocket.ConnectionTimeout) then
-            break;
-      until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
-      Fsocket.NonBlockMode := b;
+      try
+        repeat
+          if FSocket.StopFlag then
+          begin
+            FSocket.StopFlag:=False;
+            FLastError:=WSAECONNABORTED;
+            FLastErrorDesc:=TBlockSocket.GetErrorDesc(WSAECONNABORTED);
+            Exit;
+          end;
+          x := sslconnect(FSsl);
+          err := SslGetError(FSsl, x);
+          if err = SSL_ERROR_WANT_READ then
+            if not FSocket.CanRead(FSocket.ConnectionTimeout) then
+            begin
+              SetWaitError;
+              Exit;
+            end;
+          if err = SSL_ERROR_WANT_WRITE then
+            if not FSocket.CanWrite(FSocket.ConnectionTimeout) then
+            begin
+              SetWaitError;
+              Exit;
+            end;
+        until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
+      finally
+        Fsocket.NonBlockMode := b;
+      end;
       if err <> SSL_ERROR_NONE then
       begin
         SSLcheck;
@@ -619,31 +667,63 @@ end;
 function TSSLOpenSSL.SendBuffer(Buffer: TMemory; Len: Integer): Integer;
 var
   err: integer;
+  StartTick: LongWord;
+  OldNonBlockMode: Boolean;
 {$IFDEF CIL}
   s: ansistring;
 {$ENDIF}
 begin
   FLastError := 0;
   FLastErrorDesc := '';
-  repeat
+  StartTick:=GetTick;
+  OldNonBlockMode:=FSocket.NonBlockMode;
+  if (DataTimeout >= 0) and not OldNonBlockMode then
+    FSocket.NonBlockMode:=True;
+  try
+    repeat
+      if FSocket.StopFlag then
+      begin
+        FSocket.StopFlag:=False;
+        FLastError:=WSAECONNABORTED;
+        FLastErrorDesc:=TBlockSocket.GetErrorDesc(WSAECONNABORTED);
+        Result:=0;
+        Exit;
+      end;
 {$IFDEF CIL}
-    s := StringOf(Buffer);
-    Result := SslWrite(FSsl, s, Len);
+      s := StringOf(Buffer);
+      Result := SslWrite(FSsl, s, Len);
 {$ELSE}
-    Result := SslWrite(FSsl, Buffer , Len);
+      Result := SslWrite(FSsl, Buffer , Len);
 {$ENDIF}
-    err := SslGetError(FSsl, Result);
-  until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
+      err := SslGetError(FSsl, Result);
+      if (DataTimeout >= 0) and
+         ((err = SSL_ERROR_WANT_READ) or (err = SSL_ERROR_WANT_WRITE)) then
+        if not WaitForIO(err, StartTick) then
+        begin
+          Result:=0;
+          Exit;
+        end;
+    until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
+  finally
+    if (DataTimeout >= 0) and not OldNonBlockMode then
+      FSocket.NonBlockMode:=OldNonBlockMode;
+  end;
   if err = SSL_ERROR_ZERO_RETURN then
-    Result := 0
+  begin
+    Result:=0;
+    FLastError:=WSAECONNRESET;
+    FLastErrorDesc:=TBlockSocket.GetErrorDesc(WSAECONNRESET);
+  end
   else
     if (err <> 0) then
-      FLastError := err;
+      FLastError:=err;
 end;
 
 function TSSLOpenSSL.RecvBuffer(Buffer: TMemory; Len: Integer): Integer;
 var
   err: integer;
+  StartTick: LongWord;
+  OldNonBlockMode: Boolean;
 {$IFDEF CIL}
   sb: stringbuilder;
   s: ansistring;
@@ -651,27 +731,51 @@ var
 begin
   FLastError := 0;
   FLastErrorDesc := '';
-  repeat
+  StartTick:=GetTick;
+  OldNonBlockMode:=FSocket.NonBlockMode;
+  if (DataTimeout >= 0) and not OldNonBlockMode then
+    FSocket.NonBlockMode:=True;
+  try
+    repeat
+      if FSocket.StopFlag then
+      begin
+        FSocket.StopFlag:=False;
+        FLastError:=WSAECONNABORTED;
+        FLastErrorDesc:=TBlockSocket.GetErrorDesc(WSAECONNABORTED);
+        Result:=0;
+        Exit;
+      end;
 {$IFDEF CIL}
-    sb := StringBuilder.Create(Len);
-    Result := SslRead(FSsl, sb, Len);
-    if Result > 0 then
-    begin
-      sb.Length := Result;
-      s := sb.ToString;
-      System.Array.Copy(BytesOf(s), Buffer, length(s));
-    end;
+      sb := StringBuilder.Create(Len);
+      Result := SslRead(FSsl, sb, Len);
+      if Result > 0 then
+      begin
+        sb.Length := Result;
+        s := sb.ToString;
+        System.Array.Copy(BytesOf(s), Buffer, length(s));
+      end;
 {$ELSE}
-    Result := SslRead(FSsl, Buffer , Len);
+      Result := SslRead(FSsl, Buffer , Len);
 {$ENDIF}
-    err := SslGetError(FSsl, Result);
-  until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
+      err := SslGetError(FSsl, Result);
+      if (DataTimeout >= 0) and
+         ((err = SSL_ERROR_WANT_READ) or (err = SSL_ERROR_WANT_WRITE)) then
+        if not WaitForIO(err, StartTick) then
+        begin
+          Result:=0;
+          Exit;
+        end;
+    until (err <> SSL_ERROR_WANT_READ) and (err <> SSL_ERROR_WANT_WRITE);
+  finally
+    if (DataTimeout >= 0) and not OldNonBlockMode then
+      FSocket.NonBlockMode:=OldNonBlockMode;
+  end;
   if err = SSL_ERROR_ZERO_RETURN then
-    Result := 0
+    Result:=0
   {pf}// Verze 1.1.0 byla s else tak jak to ted mam,
       // ve verzi 1.1.1 bylo ELSE zruseno, ale pak je SSL_ERROR_ZERO_RETURN
       // propagovano jako Chyba.
-  {pf} else {/pf} if (err <> 0) then   
+  {pf} else {/pf} if (err <> 0) then
     FLastError := err;
 end;
 


### PR DESCRIPTION
## Summary

- make TCP, TLS, and HTTP waits cancellable while disconnecting
- keep ownership of the RPC worker until it has fully stopped
- preserve configured request timeouts, keep-alive probes, and reconnect behavior

## Root cause

Changing `Http.Timeout` during disconnect does not shorten a socket wait that
has already started. The RPC worker also cleared its owner pointer before its
final accesses, so the main thread could mistake that for thread completion.
Blocking TLS application I/O could additionally bypass the heartbeat path when
only part of a TLS record had arrived.

## Implementation

- use a non-freeing RPC worker and join it before releasing RPC state
- enable heartbeat-driven cancellation and non-blocking socket sends
- make OpenSSL application reads and writes wait through cancellable socket
  polling while preserving per-request timeout overrides
- discard incomplete keep-alive connections after request failures
- retain immediate `CanRead(0)` and `CanWrite(0)` probe semantics

## Validation

- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/`
- `make LAZARUS_DIR=/usr/lib/lazarus/default all`
- fault injection for stalled TLS handshakes, partial TLS records, and blocked
  HTTP sends; disconnect completed in about 100 ms
- delayed TLS response, clean TLS EOF, zero timeout, and keep-alive regression
  checks
- local CodeRabbit, Claude, OpenCode, Mimo, Kilo, and Grok review loops found
  no blocking issues

Synchronous DNS resolution remains governed by the system resolver and cannot
be interrupted through Synapse's socket heartbeat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel network waits, join the RPC worker, and reset cancellation state on reconnect and shutdown to prevent hangs when disconnecting from a remote daemon. TCP/TLS/HTTP waits are now interruptible via heartbeat and `Http.Abort` without changing request timeouts or keep‑alive behavior.

- **Bug Fixes**
  - Cancel blocking waits using socket heartbeat; create sockets in non‑blocking mode and surface aborts as WSAECONNABORTED.
  - Stop and join the RPC worker deterministically with `StopRpcThread` (`Http.Abort`, TLS `Shutdown`, socket abort); reset stop flags before reuse; fix “connecting” status to ignore finished threads.
  - Make TLS I/O honor per‑request timeouts via `SSL.DataTimeout` with non‑blocking polling; map clean TLS close to a reset on sends.
  - Apply timeouts to TCP/TLS handshakes; if `ConnectTimeout=0`, fall back to `Http.Timeout`; report non‑blocking connect errors via `SO_ERROR`.
  - Restore request‑specific timeouts after each call and drop incomplete keep‑alive connections on failures; ensure clean teardown on object destroy.

<sup>Written for commit 1e16ef1861af5499e680b93f7f2e82b77c4e6ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS application-data timeout support for encrypted traffic.
* **Bug Fixes**
  * Improved RPC lifecycle with safer thread shutdown/teardown and more accurate “connecting” status.
  * Refined per-request timeout handling by temporarily applying request-specific socket/TLS timeouts and restoring prior settings.
  * Prevented timeout/abort paths from overwriting existing socket error details; enhanced non-blocking TLS connect/send/receive to honor stop signals and abort cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->