### PR TITLE
Prevent denial of service in HTTP error body sanitization

### DIFF
--- a/rpc.pas
+++ b/rpc.pas
@@ -829,6 +829,30 @@ begin
 end;
 
 function TRpc.SendRequest(req: TJSONObject; ReturnArguments: boolean; ATimeOut: integer): TJSONObject;
+
+  procedure StripHtmlTags(var AText: string);
+  var
+    ReadPos, WritePos: integer;
+  begin
+    ReadPos:=1;
+    WritePos:=1;
+    while ReadPos <= Length(AText) do begin
+      if AText[ReadPos] = '<' then begin
+        Inc(ReadPos);
+        while (ReadPos <= Length(AText)) and (AText[ReadPos] <> '>') do
+          Inc(ReadPos);
+        if ReadPos <= Length(AText) then
+          Inc(ReadPos);
+      end
+      else begin
+        AText[WritePos]:=AText[ReadPos];
+        Inc(WritePos);
+        Inc(ReadPos);
+      end;
+    end;
+    SetLength(AText, WritePos - 1);
+  end;
+
 var
   obj: TJSONData;
   res: TJSONObject;
@@ -930,16 +954,7 @@ begin
             s:=StringReplace(s, '</p>', LineEnding, [rfReplaceAll, rfIgnoreCase]);
             s:=StringReplace(s, '</h1>', LineEnding, [rfReplaceAll, rfIgnoreCase]);
             s:=StringReplace(s, '<li>', LineEnding+'* ', [rfReplaceAll, rfIgnoreCase]);
-            j:=1;
-            while j <= Length(s) do begin
-              if s[j] = '<' then begin
-                while (j <= Length(s)) and (s[j] <> '>') do
-                  System.Delete(s, j, 1);
-                System.Delete(s, j, 1);
-              end
-              else
-                Inc(j);
-            end;
+            StripHtmlTags(s);
             while Pos('  ', s) > 0 do
               s:=StringReplace(s, '  ', ' ', [rfReplaceAll]);
             while Pos(LineEnding + ' ', s) > 0 do


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled non-200 HTTP response bodies containing many or unterminated `<...>` tags from causing quadratic processing and a CPU denial of service in `TRpc.SendRequest`.

### Description

- Replace repeated in-place tag deletions with a local `StripHtmlTags` helper that uses a single read/write pass and truncates the string once.
- Keep the helper local to `TRpc.SendRequest` and preserve the existing replacements, whitespace normalization, trimming, fallback error handling, and malformed-tag behavior.
- Limit the change to HTTP error-body display sanitization in `rpc.pas`; RPC behavior and public interfaces remain unchanged.

### Testing

- `git diff --check origin/master...HEAD` passed.
- Compiled and ran an FPC 3.0.4 equivalence harness covering 349,537 exhaustive and explicit cases, including empty input, tag-only input, consecutive tags, and an unclosed `<`; all outputs matched the previous implementation.
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/` completed successfully.
- `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ all` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fa9a77608327b90e0b965abdfd26)


---
## Summary by cubic
Make HTTP error tag stripping in TRpc.SendRequest linear to prevent DoS from crafted responses. Uses a local single-pass read/write scan to remove tags, preserving existing replacements and malformed-tag behavior; only affects non-200 responses.

<sup>Written for commit 1cfa42772e05299409ac3db91f8429eb16b4ea27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1525?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>




## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of HTML content in HTTP error messages to produce cleaner, more readable output.
  * Error responses are now processed more reliably, with consistent whitespace normalization and trimming.




## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting by removing HTML tags from failed request responses.
  * Preserved readable text while continuing to normalize and trim excess whitespace.

