### PR TITLE
Enable TLS certificate and hostname verification for HTTPS RPC

### DIFF
--- a/rpc.pas
+++ b/rpc.pas
@@ -745,8 +745,8 @@ procedure TRpc.InitSSL;
 {$ifndef darwin}
   procedure CheckOpenSSL;
   const
-  OpenSSLVersions: array[1..6] of string =
-  ('3', '1.1', '1.1.0', '1.0.2', '1.0.0', '0.9.8');
+  OpenSSLVersions: array[1..5] of string =
+  ('3', '1.1', '1.1.0', '1.0.2', '1.0.0');
   var
     hLib1, hLib2: TLibHandle;
     i: integer;
@@ -1188,6 +1188,7 @@ begin
   Ini.WriteInteger('NetWork', 'HttpTimeout', i);
   Http.Timeout:= i * 1000;
   Http.Sock.SSL.DataTimeout:=Http.Timeout;
+  Http.Sock.SSL.VerifyCert:=True;
   Http.Sock.NonblockSendTimeout:=Http.Timeout;
 
   i := Ini.ReadInteger('NetWork', 'ConnectTimeout', 0);

--- a/synapse/source/lib/ssl_openssl.pas
+++ b/synapse/source/lib/ssl_openssl.pas
@@ -92,7 +92,7 @@ interface
 
 uses
   SysUtils, Classes,
-  blcksock, synsock, synautil,
+  blcksock, synsock, synautil, synaip,
 {$IFDEF CIL}
   System.Text,
 {$ENDIF}
@@ -107,13 +107,14 @@ type
     FSsl: PSSL;
     Fctx: PSSL_CTX;
     function SSLCheck: Boolean;
-    function SetSslKeys: boolean;
+    function SetSslKeys(server:Boolean): boolean;
     function Init(server:Boolean): Boolean;
     function DeInit: Boolean;
     function Prepare(server:Boolean): Boolean;
     procedure SetWaitError;
     function WaitForIO(Error: integer; StartTick: LongWord): Boolean;
     function LoadPFX(pfxdata: ansistring): Boolean;
+    function ConfigureHostVerification: Boolean;
     function CreateSelfSignedCert(Host: string): Boolean; override;
   public
     {:See @inherited}
@@ -164,6 +165,526 @@ type
   end;
 
 implementation
+
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+uses
+  Windows;
+
+type
+  TWinCertContext = record
+    EncodingType: DWORD;
+    EncodedData: PByte;
+    EncodedSize: DWORD;
+    CertInfo: Pointer;
+    CertStore: Pointer;
+  end;
+  PWinCertContext = ^TWinCertContext;
+  TPAnsiCharArray = array[0..0] of PAnsiChar;
+  PPAnsiCharArray = ^TPAnsiCharArray;
+  TWinCertEnhKeyUsage = record
+    UsageIdentifierCount: DWORD;
+    UsageIdentifiers: PPAnsiCharArray;
+  end;
+  PWinCertEnhKeyUsage = ^TWinCertEnhKeyUsage;
+
+const
+  CRYPT_E_NOT_FOUND = DWORD($80092004);
+  X509_ASN_ENCODING = $00000001;
+  PKCS_7_ASN_ENCODING = $00010000;
+  CERT_FIND_EXISTING = $000D0000;
+  CERT_STORE_PROV_SYSTEM_A = 9;
+  CERT_STORE_READONLY_FLAG = $00008000;
+  CERT_SYSTEM_STORE_CURRENT_USER = $00010000;
+  CERT_SYSTEM_STORE_LOCAL_MACHINE = $00020000;
+  ANY_ENHANCED_KEY_USAGE_OID = '2.5.29.37.0';
+  SERVER_AUTH_OID = '1.3.6.1.5.5.7.3.1';
+  X509_R_CERT_ALREADY_IN_HASH_TABLE = 101;
+
+threadvar
+  WindowsVerifyError: string;
+  WindowsCurrentUserDisallowedStore: Pointer;
+  WindowsLocalMachineDisallowedStore: Pointer;
+
+function WinCertOpenStore(Provider: Pointer; EncodingType: DWORD;
+  CryptProvider: PtrUInt; Flags: DWORD; StoreName: Pointer): Pointer; stdcall;
+  external 'crypt32.dll' name 'CertOpenStore';
+function WinCertEnumCertificatesInStore(Store: Pointer;
+  Previous: PWinCertContext): PWinCertContext; stdcall;
+  external 'crypt32.dll' name 'CertEnumCertificatesInStore';
+function WinCertCreateCertificateContext(EncodingType: DWORD;
+  EncodedData: PByte; EncodedSize: DWORD): PWinCertContext; stdcall;
+  external 'crypt32.dll' name 'CertCreateCertificateContext';
+function WinCertFindCertificateInStore(Store: Pointer; EncodingType: DWORD;
+  FindFlags: DWORD; FindType: DWORD; FindParameter: Pointer;
+  Previous: PWinCertContext): PWinCertContext; stdcall;
+  external 'crypt32.dll' name 'CertFindCertificateInStore';
+function WinCertGetEnhancedKeyUsage(CertContext: PWinCertContext; Flags: DWORD;
+  Usage: PWinCertEnhKeyUsage; var UsageSize: DWORD): LongBool; stdcall;
+  external 'crypt32.dll' name 'CertGetEnhancedKeyUsage';
+function WinCertFreeCertificateContext(CertContext: PWinCertContext): LongBool;
+  stdcall; external 'crypt32.dll' name 'CertFreeCertificateContext';
+function WinCertCloseStore(Store: Pointer; Flags: DWORD): LongBool;
+  stdcall; external 'crypt32.dll' name 'CertCloseStore';
+
+function OpenWindowsCertificateStore(const StoreName: PAnsiChar;
+  Location: DWORD): Pointer;
+begin
+  Result := WinCertOpenStore(Pointer(PtrUInt(CERT_STORE_PROV_SYSTEM_A)), 0, 0,
+    Location or CERT_STORE_READONLY_FLAG, StoreName);
+end;
+
+function OpenWindowsDisallowedStores(out ErrorDescription: string): Boolean;
+begin
+  Result := False;
+  ErrorDescription := '';
+  WindowsVerifyError := '';
+  WindowsCurrentUserDisallowedStore :=
+    OpenWindowsCertificateStore('Disallowed',
+      CERT_SYSTEM_STORE_CURRENT_USER);
+  if WindowsCurrentUserDisallowedStore = nil then
+  begin
+    ErrorDescription :=
+      'Unable to open the current-user Windows Disallowed certificate store.';
+    Exit;
+  end;
+  WindowsLocalMachineDisallowedStore :=
+    OpenWindowsCertificateStore('Disallowed',
+      CERT_SYSTEM_STORE_LOCAL_MACHINE);
+  if WindowsLocalMachineDisallowedStore = nil then
+  begin
+    WinCertCloseStore(WindowsCurrentUserDisallowedStore, 0);
+    WindowsCurrentUserDisallowedStore := nil;
+    ErrorDescription :=
+      'Unable to open the local-machine Windows Disallowed certificate store.';
+    Exit;
+  end;
+  Result := True;
+end;
+
+procedure CloseWindowsDisallowedStores;
+begin
+  if WindowsLocalMachineDisallowedStore <> nil then
+    WinCertCloseStore(WindowsLocalMachineDisallowedStore, 0);
+  if WindowsCurrentUserDisallowedStore <> nil then
+    WinCertCloseStore(WindowsCurrentUserDisallowedStore, 0);
+  WindowsLocalMachineDisallowedStore := nil;
+  WindowsCurrentUserDisallowedStore := nil;
+  WindowsVerifyError := '';
+end;
+
+function EncodedCertificateInStore(Store: Pointer; EncodedData: PByte;
+  EncodedSize: DWORD; out LookupFailed: Boolean): Boolean;
+var
+  Certificate: PWinCertContext;
+  Match: PWinCertContext;
+  FindError: DWORD;
+begin
+  Result := False;
+  LookupFailed := True;
+  Certificate := WinCertCreateCertificateContext(X509_ASN_ENCODING,
+    EncodedData, EncodedSize);
+  if Certificate = nil then
+    Exit;
+  try
+    Match := WinCertFindCertificateInStore(Store,
+      X509_ASN_ENCODING or PKCS_7_ASN_ENCODING, 0, CERT_FIND_EXISTING,
+      Certificate, nil);
+    if Match = nil then
+    begin
+      FindError := GetLastError;
+      LookupFailed := FindError <> CRYPT_E_NOT_FOUND;
+      Exit;
+    end;
+    WinCertFreeCertificateContext(Match);
+    LookupFailed := False;
+    Result := True;
+  finally
+    WinCertFreeCertificateContext(Certificate);
+  end;
+end;
+
+function X509CertificateInStore(Store: Pointer; Certificate: PX509;
+  out CheckFailed: Boolean): Boolean;
+var
+  Bio: PBIO;
+  DER: AnsiString;
+  DERSize: integer;
+begin
+  Result := False;
+  CheckFailed := True;
+  if Certificate = nil then
+    Exit;
+  Bio := BioNew(BioSMem);
+  if Bio = nil then
+    Exit;
+  try
+    if i2dX509bio(Bio, Certificate) <> 1 then
+      Exit;
+    DERSize := BioCtrlPending(Bio);
+    if DERSize <= 0 then
+      Exit;
+    SetLength(DER, DERSize);
+    if BioRead(Bio, DER, DERSize) <> DERSize then
+      Exit;
+    Result := EncodedCertificateInStore(Store, PByte(PAnsiChar(DER)),
+      DWORD(DERSize), CheckFailed);
+  finally
+    BioFreeAll(Bio);
+  end;
+end;
+
+function WindowsCertificateAllowsServerAuth(CertContext: PWinCertContext;
+  out CheckFailed: Boolean): Boolean;
+var
+  UsageBuffer: Pointer;
+  Usage: PWinCertEnhKeyUsage;
+  UsageSize: DWORD;
+  UsageError: DWORD;
+  I: DWORD;
+begin
+  Result := False;
+  CheckFailed := True;
+  UsageBuffer := nil;
+  UsageSize := 0;
+  SetLastError(ERROR_SUCCESS);
+  if not WinCertGetEnhancedKeyUsage(CertContext, 0, nil, UsageSize) then
+  begin
+    UsageError := GetLastError;
+    if UsageError = CRYPT_E_NOT_FOUND then
+    begin
+      CheckFailed := False;
+      Result := True;
+    end;
+    Exit;
+  end;
+  if (UsageSize < SizeOf(TWinCertEnhKeyUsage))
+    or (UsageSize > DWORD(High(Integer))) then
+    Exit;
+  GetMem(UsageBuffer, UsageSize);
+  try
+    Usage := PWinCertEnhKeyUsage(UsageBuffer);
+    SetLastError(ERROR_SUCCESS);
+    if not WinCertGetEnhancedKeyUsage(CertContext, 0, Usage, UsageSize) then
+      Exit;
+    if Usage^.UsageIdentifierCount = 0 then
+    begin
+      UsageError := GetLastError;
+      CheckFailed := False;
+      Result := UsageError = CRYPT_E_NOT_FOUND;
+      Exit;
+    end;
+    if Usage^.UsageIdentifiers = nil then
+      Exit;
+    for I := 0 to Usage^.UsageIdentifierCount - 1 do
+      if (Usage^.UsageIdentifiers^[I] <> nil)
+        and ((StrComp(Usage^.UsageIdentifiers^[I],
+          ANY_ENHANCED_KEY_USAGE_OID) = 0)
+        or (StrComp(Usage^.UsageIdentifiers^[I], SERVER_AUTH_OID) = 0)) then
+      begin
+        CheckFailed := False;
+        Result := True;
+        Exit;
+      end;
+    CheckFailed := False;
+  finally
+    FreeMem(UsageBuffer);
+  end;
+end;
+
+function WindowsVerifyCallback(PreverifyOk: integer;
+  StoreContext: PX509_STORE_CTX): integer; cdecl;
+var
+  Certificate: PX509;
+  CheckFailed: Boolean;
+begin
+  Result := 0;
+  if PreverifyOk = 0 then
+    Exit;
+  try
+    Certificate := X509StoreCtxGetCurrentCert(StoreContext);
+    if Certificate = nil then
+    begin
+      WindowsVerifyError :=
+        'OpenSSL did not provide the current certificate in the peer chain.';
+      Exit;
+    end;
+    if WindowsCurrentUserDisallowedStore = nil then
+    begin
+      WindowsVerifyError :=
+        'Unable to open the current-user Windows Disallowed certificate store.';
+      Exit;
+    end;
+    if WindowsLocalMachineDisallowedStore = nil then
+    begin
+      WindowsVerifyError :=
+        'Unable to open the local-machine Windows Disallowed certificate store.';
+      Exit;
+    end;
+    if X509CertificateInStore(WindowsCurrentUserDisallowedStore, Certificate,
+      CheckFailed) then
+    begin
+      WindowsVerifyError :=
+        'The Windows certificate policy distrusts a certificate in the peer chain.';
+      Exit;
+    end;
+    if CheckFailed then
+    begin
+      WindowsVerifyError :=
+        'Unable to check the current-user Windows Disallowed certificate store.';
+      Exit;
+    end;
+    if X509CertificateInStore(WindowsLocalMachineDisallowedStore, Certificate,
+      CheckFailed) then
+    begin
+      WindowsVerifyError :=
+        'The Windows certificate policy distrusts a certificate in the peer chain.';
+      Exit;
+    end;
+    if CheckFailed then
+    begin
+      WindowsVerifyError :=
+        'Unable to check the local-machine Windows Disallowed certificate store.';
+      Exit;
+    end;
+    Result := 1;
+  except
+    WindowsVerifyError :=
+      'Unable to apply the Windows certificate distrust policy.';
+    Result := 0;
+  end;
+end;
+
+function ImportWindowsRootStore(Store: Pointer; CurrentUserDisallowed: Pointer;
+  LocalMachineDisallowed: Pointer; OpenSSLStore: PX509_STORE;
+  var LoadedCount: integer; out ErrorDescription: string): Boolean;
+var
+  CertContext: PWinCertContext;
+  Bio: PBIO;
+  Cert: PX509;
+  DER: AnsiString;
+  EnumError: DWORD;
+  OpenSSLError: integer;
+  UsageCheckFailed: Boolean;
+  DisallowedLookupFailed: Boolean;
+begin
+  Result := False;
+  CertContext := nil;
+  try
+    while True do
+    begin
+      CertContext := WinCertEnumCertificatesInStore(Store, CertContext);
+      if CertContext = nil then
+      begin
+        EnumError := GetLastError;
+        if (EnumError <> CRYPT_E_NOT_FOUND)
+          and (EnumError <> ERROR_NO_MORE_FILES) then
+        begin
+          ErrorDescription :=
+            'Unable to enumerate a Windows ROOT certificate store.';
+          Exit;
+        end;
+        Break;
+      end;
+      if (CertContext^.EncodedSize = 0)
+        or (CertContext^.EncodedSize > DWORD(High(Integer))) then
+      begin
+        ErrorDescription :=
+          'A Windows ROOT certificate store contains an invalid certificate.';
+        Exit;
+      end;
+      if not WindowsCertificateAllowsServerAuth(CertContext,
+        UsageCheckFailed) then
+      begin
+        if UsageCheckFailed then
+        begin
+          ErrorDescription :=
+            'Unable to check a Windows root certificate trust purpose.';
+          Exit;
+        end;
+        Continue;
+      end;
+      if EncodedCertificateInStore(CurrentUserDisallowed,
+        CertContext^.EncodedData, CertContext^.EncodedSize,
+        DisallowedLookupFailed) then
+        Continue;
+      if DisallowedLookupFailed then
+      begin
+        ErrorDescription :=
+          'Unable to check the current-user Windows Disallowed certificate store.';
+        Exit;
+      end;
+      if EncodedCertificateInStore(LocalMachineDisallowed,
+        CertContext^.EncodedData, CertContext^.EncodedSize,
+        DisallowedLookupFailed) then
+        Continue;
+      if DisallowedLookupFailed then
+      begin
+        ErrorDescription :=
+          'Unable to check the local-machine Windows Disallowed certificate store.';
+        Exit;
+      end;
+      SetString(DER, PAnsiChar(CertContext^.EncodedData),
+        CertContext^.EncodedSize);
+      Bio := BioNew(BioSMem);
+      if Bio = nil then
+      begin
+        ErrorDescription := 'OpenSSL could not allocate a certificate buffer.';
+        Exit;
+      end;
+      try
+        if BioWrite(Bio, DER, Length(DER)) <> Length(DER) then
+        begin
+          ErrorDescription := 'OpenSSL could not read a Windows root certificate.';
+          Exit;
+        end;
+        Cert := d2iX509bio(Bio, nil);
+        if Cert = nil then
+        begin
+          ErrorDescription := 'OpenSSL could not decode a Windows root certificate.';
+          Exit;
+        end;
+        try
+          ErrClearError;
+          if X509StoreAddCert(OpenSSLStore, Cert) = 1 then
+            Inc(LoadedCount)
+          else
+          begin
+            OpenSSLError := ErrGetError;
+            if (OpenSSLError and $fff) <> X509_R_CERT_ALREADY_IN_HASH_TABLE then
+            begin
+              ErrorDescription :=
+                'OpenSSL could not trust a Windows root certificate.';
+              Exit;
+            end;
+            ErrClearError;
+            Inc(LoadedCount);
+          end;
+        finally
+          X509Free(Cert);
+        end;
+      finally
+        BioFreeAll(Bio);
+      end;
+    end;
+    Result := True;
+  finally
+    if CertContext <> nil then
+      WinCertFreeCertificateContext(CertContext);
+  end;
+end;
+
+function LoadDefaultVerifyPaths(Ctx: PSSL_CTX;
+  out ErrorDescription: string): Boolean;
+var
+  CurrentUserRoot: Pointer;
+  LocalMachineRoot: Pointer;
+  CurrentUserDisallowed: Pointer;
+  LocalMachineDisallowed: Pointer;
+  OpenSSLStore: PX509_STORE;
+  LoadedCount: integer;
+begin
+  Result := False;
+  ErrorDescription := '';
+  LoadedCount := 0;
+  if not SSLWindowsCertificateVerificationAvailable then
+  begin
+    ErrorDescription :=
+      'Windows certificate policy checks require OpenSSL 1.0.2 or later.';
+    Exit;
+  end;
+  CurrentUserRoot := OpenWindowsCertificateStore('ROOT',
+    CERT_SYSTEM_STORE_CURRENT_USER);
+  if CurrentUserRoot = nil then
+  begin
+    ErrorDescription :=
+      'Unable to open the current-user Windows ROOT certificate store.';
+    Exit;
+  end;
+  LocalMachineRoot := OpenWindowsCertificateStore('ROOT',
+    CERT_SYSTEM_STORE_LOCAL_MACHINE);
+  if LocalMachineRoot = nil then
+  begin
+    WinCertCloseStore(CurrentUserRoot, 0);
+    ErrorDescription :=
+      'Unable to open the local-machine Windows ROOT certificate store.';
+    Exit;
+  end;
+  CurrentUserDisallowed := OpenWindowsCertificateStore('Disallowed',
+    CERT_SYSTEM_STORE_CURRENT_USER);
+  if CurrentUserDisallowed = nil then
+  begin
+    WinCertCloseStore(LocalMachineRoot, 0);
+    WinCertCloseStore(CurrentUserRoot, 0);
+    ErrorDescription :=
+      'Unable to open the current-user Windows Disallowed certificate store.';
+    Exit;
+  end;
+  LocalMachineDisallowed := OpenWindowsCertificateStore('Disallowed',
+    CERT_SYSTEM_STORE_LOCAL_MACHINE);
+  if LocalMachineDisallowed = nil then
+  begin
+    WinCertCloseStore(CurrentUserDisallowed, 0);
+    WinCertCloseStore(LocalMachineRoot, 0);
+    WinCertCloseStore(CurrentUserRoot, 0);
+    ErrorDescription :=
+      'Unable to open the local-machine Windows Disallowed certificate store.';
+    Exit;
+  end;
+  try
+    OpenSSLStore := SslCtxGetCertStore(Ctx);
+    if OpenSSLStore = nil then
+    begin
+      ErrorDescription := 'OpenSSL did not provide a certificate store.';
+      Exit;
+    end;
+    if not ImportWindowsRootStore(CurrentUserRoot, CurrentUserDisallowed,
+      LocalMachineDisallowed, OpenSSLStore, LoadedCount,
+      ErrorDescription) then
+      Exit;
+    if not ImportWindowsRootStore(LocalMachineRoot, CurrentUserDisallowed,
+      LocalMachineDisallowed, OpenSSLStore, LoadedCount,
+      ErrorDescription) then
+      Exit;
+    if LoadedCount = 0 then
+    begin
+      ErrorDescription := 'The Windows certificate stores contain no trusted roots.';
+      Exit;
+    end;
+    Result := True;
+  finally
+    WinCertCloseStore(LocalMachineDisallowed, 0);
+    WinCertCloseStore(CurrentUserDisallowed, 0);
+    WinCertCloseStore(LocalMachineRoot, 0);
+    WinCertCloseStore(CurrentUserRoot, 0);
+  end;
+end;
+{$ENDIF}
+{$ENDIF}
+
+{$IFNDEF MSWINDOWS}
+function LoadDefaultVerifyPaths(Ctx: PSSL_CTX;
+  out ErrorDescription: string): Boolean;
+begin
+  Result := SslCtxSetDefaultVerifyPaths(Ctx) = 1;
+  if Result then
+    ErrorDescription := ''
+  else
+    ErrorDescription := 'OpenSSL could not load the default certificate paths.';
+end;
+{$ELSE}
+{$IFDEF CIL}
+function LoadDefaultVerifyPaths(Ctx: PSSL_CTX;
+  out ErrorDescription: string): Boolean;
+begin
+  Result := SslCtxSetDefaultVerifyPaths(Ctx) = 1;
+  if Result then
+    ErrorDescription := ''
+  else
+    ErrorDescription := 'OpenSSL could not load the default certificate paths.';
+end;
+{$ENDIF}
+{$ENDIF}
 
 {==============================================================================}
 
@@ -358,12 +879,14 @@ begin
   end;
 end;
 
-function TSSLOpenSSL.SetSslKeys: boolean;
+function TSSLOpenSSL.SetSslKeys(server:Boolean): boolean;
 var
   st: TFileStream;
-  s: string;
+  s, DefaultVerifyError: string;
+  DefaultVerifyFailed: Boolean;
 begin
   Result := False;
+  DefaultVerifyFailed := False;
   if not assigned(FCtx) then
     Exit;
   try
@@ -387,6 +910,12 @@ begin
     if FCertCAFile <> '' then
       if SslCtxLoadVerifyLocations(FCtx, FCertCAFile, '') <> 1 then
         Exit;
+    if not server and FVerifyCert and (FCertCAFile = '') then
+      if not LoadDefaultVerifyPaths(FCtx, DefaultVerifyError) then
+      begin
+        DefaultVerifyFailed := True;
+        Exit;
+      end;
     if FPFXfile <> '' then
     begin
       try
@@ -410,6 +939,11 @@ begin
     Result := True;
   finally
     SSLCheck;
+    if DefaultVerifyFailed then
+    begin
+      FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+      FLastErrorDesc := DefaultVerifyError;
+    end;
   end;
 end;
 
@@ -449,7 +983,25 @@ begin
     s := FCiphers;
     SslCtxSetCipherList(Fctx, s);
     if FVerifyCert then
+    begin
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+      if not SSLWindowsCertificateVerificationAvailable then
+      begin
+        FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+        FLastErrorDesc :=
+          'Windows certificate policy checks require OpenSSL 1.0.2 or later.';
+        Exit;
+      end;
+      SslCtxSetVerify(FCtx, SSL_VERIFY_PEER,
+        @WindowsVerifyCallback)
+{$ELSE}
       SslCtxSetVerify(FCtx, SSL_VERIFY_PEER, nil)
+{$ENDIF}
+{$ELSE}
+      SslCtxSetVerify(FCtx, SSL_VERIFY_PEER, nil)
+{$ENDIF}
+    end
     else
       SslCtxSetVerify(FCtx, SSL_VERIFY_NONE, nil);
 {$IFNDEF CIL}
@@ -463,7 +1015,7 @@ begin
       CreateSelfSignedcert(FSocket.ResolveIPToName(FSocket.GetRemoteSinIP));
     end;
 
-    if not SetSSLKeys then
+    if not SetSSLKeys(server) then
       Exit
     else
     begin
@@ -534,15 +1086,59 @@ begin
     SetWaitError;
 end;
 
+function NormalizeTLSIdentityHost(const Host: AnsiString;
+  out IsIPAddress: Boolean): AnsiString;
+var
+  ZoneDelimiter: integer;
+begin
+  Result := Host;
+  ZoneDelimiter := Pos('%', Result);
+  if ZoneDelimiter <> 0 then
+  begin
+    Result := Copy(Result, 1, ZoneDelimiter - 1);
+    if Pos(':', Result) <> 0 then
+    begin
+      IsIPAddress := True;
+      Exit;
+    end;
+    Result := Host;
+  end;
+  IsIPAddress := IsIP(Result) or IsIP6(Result) or (Pos(':', Result) <> 0);
+end;
+
 function TSSLOpenSSL.Connect: boolean;
 var
   x: integer;
   b: boolean;
   err: integer;
+  IdentityHost: AnsiString;
+  IdentityIsIPAddress: Boolean;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  WindowsStoreError: string;
+{$ENDIF}
+{$ENDIF}
 begin
   Result := False;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  CloseWindowsDisallowedStores;
+{$ENDIF}
+{$ENDIF}
   if FSocket.Socket = INVALID_SOCKET then
     Exit;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  if FVerifyCert then
+    if not OpenWindowsDisallowedStores(WindowsStoreError) then
+    begin
+      FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+      FLastErrorDesc := WindowsStoreError;
+      Exit;
+    end;
+  try
+{$ENDIF}
+{$ENDIF}
   if Prepare(False) then
   begin
 {$IFDEF CIL}
@@ -554,14 +1150,29 @@ begin
       SSLCheck;
       Exit;
     end;
-    if SNIHost<>'' then
-      SSLCtrl(Fssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, PAnsiChar(AnsiString(SNIHost)));
+    if FVerifyCert and (SNIHost <> '') then
+      if not ConfigureHostVerification then
+        Exit;
+    IdentityHost := NormalizeTLSIdentityHost(AnsiString(SNIHost),
+      IdentityIsIPAddress);
+    if (IdentityHost <> '') and not IdentityIsIPAddress then
+      SSLCtrl(Fssl, SSL_CTRL_SET_TLSEXT_HOSTNAME,
+        TLSEXT_NAMETYPE_host_name, PAnsiChar(IdentityHost));
     if FSocket.ConnectionTimeout <= 0 then //do blocking call of SSL_Connect
     begin
       x := sslconnect(FSsl);
       if x < 1 then
       begin
         SSLcheck;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+        if WindowsVerifyError <> '' then
+        begin
+          FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+          FLastErrorDesc := WindowsVerifyError;
+        end;
+{$ENDIF}
+{$ENDIF}
         Exit;
       end;
     end
@@ -599,6 +1210,15 @@ begin
       if err <> SSL_ERROR_NONE then
       begin
         SSLcheck;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+        if WindowsVerifyError <> '' then
+        begin
+          FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+          FLastErrorDesc := WindowsVerifyError;
+        end;
+{$ENDIF}
+{$ENDIF}
         Exit;
       end;
     end;
@@ -608,15 +1228,102 @@ begin
     FSSLEnabled := True;
     Result := True;
   end;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  finally
+    CloseWindowsDisallowedStores;
+  end;
+{$ENDIF}
+{$ENDIF}
+end;
+
+function TSSLOpenSSL.ConfigureHostVerification: Boolean;
+var
+  Param: PX509_VERIFY_PARAM;
+  Host: AnsiString;
+  HostIsIPAddress: Boolean;
+begin
+  Result := False;
+  Host := NormalizeTLSIdentityHost(AnsiString(SNIHost), HostIsIPAddress);
+  if Host = '' then
+  begin
+    FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+    FLastErrorDesc := 'TLS hostname verification requires a target hostname.';
+    Exit;
+  end;
+  if not SSLHostVerificationAvailable then
+  begin
+    FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+    FLastErrorDesc := 'TLS hostname verification requires OpenSSL 1.0.2 or later.';
+    Exit;
+  end;
+{$IFDEF CIL}
+  try
+{$ENDIF}
+  Param := SslGet0Param(Fssl);
+  if Param = nil then
+  begin
+    FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+    FLastErrorDesc := 'OpenSSL did not provide certificate verification parameters.';
+    Exit;
+  end;
+  if HostIsIPAddress then
+    Result := X509VerifyParamSet1IPAsc(Param, Host) = 1
+  else
+  begin
+    X509VerifyParamSetHostFlags(Param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    Result := X509VerifyParamSet1Host(Param, Host, 0) = 1;
+  end;
+  if not Result then
+  begin
+    if SSLCheck then
+    begin
+      FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+      FLastErrorDesc := 'OpenSSL rejected the TLS verification hostname.';
+    end;
+  end;
+{$IFDEF CIL}
+  except
+    on Exception do
+    begin
+      Result := False;
+      FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+      FLastErrorDesc :=
+        'TLS hostname verification is unavailable in the loaded OpenSSL runtime.';
+    end;
+  end;
+{$ENDIF}
 end;
 
 function TSSLOpenSSL.Accept: boolean;
 var
   x: integer;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  WindowsStoreError: string;
+{$ENDIF}
+{$ENDIF}
 begin
   Result := False;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  CloseWindowsDisallowedStores;
+{$ENDIF}
+{$ENDIF}
   if FSocket.Socket = INVALID_SOCKET then
     Exit;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  if FVerifyCert then
+    if not OpenWindowsDisallowedStores(WindowsStoreError) then
+    begin
+      FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+      FLastErrorDesc := WindowsStoreError;
+      Exit;
+    end;
+  try
+{$ENDIF}
+{$ENDIF}
   if Prepare(True) then
   begin
 {$IFDEF CIL}
@@ -632,11 +1339,27 @@ begin
     if x < 1 then
     begin
       SSLcheck;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+      if WindowsVerifyError <> '' then
+      begin
+        FLastError := X509_V_ERR_APPLICATION_VERIFICATION;
+        FLastErrorDesc := WindowsVerifyError;
+      end;
+{$ENDIF}
+{$ENDIF}
       Exit;
     end;
     FSSLEnabled := True;
     Result := True;
   end;
+{$IFDEF MSWINDOWS}
+{$IFNDEF CIL}
+  finally
+    CloseWindowsDisallowedStores;
+  end;
+{$ENDIF}
+{$ENDIF}
 end;
 
 function TSSLOpenSSL.Shutdown: boolean;

--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -147,14 +147,19 @@ var
 type
 {$IFDEF CIL}
   SslPtr = IntPtr;
+  SslSize = UIntPtr;
 {$ELSE}
   SslPtr = Pointer;
+  SslSize = PtrUInt;
 {$ENDIF}
   PSslPtr = ^SslPtr;
   PSSL_CTX = SslPtr;
   PSSL = SslPtr;
   PSSL_METHOD = SslPtr;
   PX509 = SslPtr;
+  PX509_STORE = SslPtr;
+  PX509_STORE_CTX = SslPtr;
+  PX509_VERIFY_PARAM = SslPtr;
   PX509_NAME = SslPtr;
   PEVP_MD	= SslPtr;
   PInteger = ^Integer;
@@ -166,6 +171,8 @@ type
   PASN1_INTEGER = SslPtr;
   PPasswdCb = SslPtr;
   PFunction = procedure;
+  TSSLVerifyCallback = function(PreverifyOk: Integer;
+    StoreContext: PX509_STORE_CTX): Integer; cdecl;
   PSTACK = SslPtr; {pf}
   TSkPopFreeFunc = procedure(p:SslPtr); cdecl; {pf}
   TX509Free = procedure(x: PX509); cdecl; {pf}
@@ -246,6 +253,7 @@ const
 
   SSL_CTRL_SET_TLSEXT_HOSTNAME = 55;
   TLSEXT_NAMETYPE_host_name = 0;
+  X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS = $4;
 
 var
   SSLLibHandle: TLibHandle = 0;
@@ -381,6 +389,16 @@ var
 
   [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'SSL_CTX_set_default_verify_paths')]
+    function SslCtxSetDefaultVerifyPaths(ctx: PSSL_CTX):Integer; external;
+
+  [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'SSL_CTX_get_cert_store')]
+    function SslCtxGetCertStore(ctx: PSSL_CTX):PX509_STORE; external;
+
+  [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
     EntryPoint = 'SSL_CTX_ctrl')]
     function SslCtxCtrl(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: IntPtr): integer; external;
 
@@ -442,7 +460,8 @@ var
   [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
     EntryPoint = 'SSL_CTX_set_verify')]
-    procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer; arg2: PFunction); external;
+    procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer;
+      arg2: TSSLVerifyCallback); external;
 
   [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
@@ -466,6 +485,11 @@ var
 
   [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'SSL_get0_param')]
+    function SslGet0Param(ssl: PSSL):PX509_VERIFY_PARAM; external;
+
+  [DllImport(DLLSSLName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
     EntryPoint = 'SSL_ctrl')]
     function SslCtrl(ssl: PSSL; cmd: integer; larg: integer; parg: IntPtr): integer; external;
 
@@ -478,6 +502,34 @@ var
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
     EntryPoint = 'X509_free')]
     procedure X509Free(x: PX509); external;
+
+  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'X509_STORE_add_cert')]
+    function X509StoreAddCert(Store: PX509_STORE; Cert: PX509):Integer; external;
+
+  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'X509_STORE_CTX_get_current_cert')]
+    function X509StoreCtxGetCurrentCert(StoreContext: PX509_STORE_CTX):PX509; external;
+
+  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'X509_VERIFY_PARAM_set_hostflags')]
+    procedure X509VerifyParamSetHostFlags(Param: PX509_VERIFY_PARAM;
+      Flags: Cardinal); external;
+
+  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'X509_VERIFY_PARAM_set1_host')]
+    function X509VerifyParamSet1Host(Param: PX509_VERIFY_PARAM;
+      Name: string; NameLen: SslSize):Integer; external;
+
+  [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
+    SetLastError = False, CallingConvention= CallingConvention.cdecl,
+    EntryPoint = 'X509_VERIFY_PARAM_set1_ip_asc')]
+    function X509VerifyParamSet1IPAsc(Param: PX509_VERIFY_PARAM;
+      IPAddress: string):Integer; external;
 
   [DllImport(DLLUtilName, CharSet = CharSet.Ansi,
     SetLastError = False, CallingConvention= CallingConvention.cdecl,
@@ -747,6 +799,8 @@ var
   procedure SslCtxSetDefaultPasswdCbUserdata(ctx: PSSL_CTX; u: SslPtr);
 //  function SslCtxLoadVerifyLocations(ctx: PSSL_CTX; const CAfile: PChar; const CApath: PChar):Integer;
   function SslCtxLoadVerifyLocations(ctx: PSSL_CTX; const CAfile: AnsiString; const CApath: AnsiString):Integer;
+  function SslCtxSetDefaultVerifyPaths(ctx: PSSL_CTX):Integer;
+  function SslCtxGetCertStore(ctx: PSSL_CTX):PX509_STORE;
   function SslCtxCtrl(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: SslPtr): integer;
   function SslNew(ctx: PSSL_CTX):PSSL;
   procedure SslFree(ssl: PSSL);
@@ -759,16 +813,26 @@ var
   function SslPending(ssl: PSSL):Integer;
   function SslGetVersion(ssl: PSSL):AnsiString;
   function SslGetPeerCertificate(ssl: PSSL):PX509;
-  procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer; arg2: PFunction);
+  procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer;
+    arg2: TSSLVerifyCallback);
   function SSLGetCurrentCipher(s: PSSL):SslPtr;
   function SSLCipherGetName(c: SslPtr): AnsiString;
   function SSLCipherGetBits(c: SslPtr; var alg_bits: Integer):Integer;
   function SSLGetVerifyResult(ssl: PSSL):Integer;
+  function SslGet0Param(ssl: PSSL):PX509_VERIFY_PARAM;
   function SSLCtrl(ssl: PSSL; cmd: integer; larg: integer; parg: SslPtr):Integer;
 
 // libeay.dll
   function X509New: PX509;
   procedure X509Free(x: PX509);
+  function X509StoreAddCert(Store: PX509_STORE; Cert: PX509):Integer;
+  function X509StoreCtxGetCurrentCert(StoreContext: PX509_STORE_CTX):PX509;
+  procedure X509VerifyParamSetHostFlags(Param: PX509_VERIFY_PARAM;
+    Flags: Cardinal);
+  function X509VerifyParamSet1Host(Param: PX509_VERIFY_PARAM;
+    const Name: AnsiString; NameLen: SslSize):Integer;
+  function X509VerifyParamSet1IPAsc(Param: PX509_VERIFY_PARAM;
+    const IPAddress: AnsiString):Integer;
   function X509NameOneline(a: PX509_NAME; var buf: AnsiString; size: Integer):AnsiString;
   function X509GetSubjectName(a: PX509):PX509_NAME;
   function X509GetIssuerName(a: PX509):PX509_NAME;
@@ -816,7 +880,7 @@ var
   function Asn1IntegerSet(a: PASN1_INTEGER; v: integer): integer;
   function Asn1IntegerGet(a: PASN1_INTEGER): integer; {pf}
   function i2dX509bio(b: PBIO; x: PX509): integer;
-  function d2iX509bio(b:PBIO; x:PX509):  PX509;    {pf}
+  function d2iX509bio(b:PBIO; x:PSslPtr):  PX509;    {pf}
   function PEMReadBioX509(b:PBIO; {var x:PX509;}x:PSslPtr; callback:PFunction; cb_arg: SslPtr):  PX509;    {pf}
   procedure SkX509PopFree(st: PSTACK; func: TSkPopFreeFunc); {pf}
 
@@ -830,6 +894,8 @@ var
 
 {$ENDIF}
 
+function SSLHostVerificationAvailable:Boolean;
+function SSLWindowsCertificateVerificationAvailable:Boolean;
 function IsSSLloaded: Boolean;
 function InitSSLInterface: Boolean;
 function DestroySSLInterface: Boolean;
@@ -873,6 +939,8 @@ type
   TSslCtxSetDefaultPasswdCb = procedure(ctx: PSSL_CTX; cb: SslPtr); cdecl;
   TSslCtxSetDefaultPasswdCbUserdata = procedure(ctx: PSSL_CTX; u: SslPtr); cdecl;
   TSslCtxLoadVerifyLocations = function(ctx: PSSL_CTX; const CAfile: PAnsiChar; const CApath: PAnsiChar):Integer; cdecl;
+  TSslCtxSetDefaultVerifyPaths = function(ctx: PSSL_CTX):Integer; cdecl;
+  TSslCtxGetCertStore = function(ctx: PSSL_CTX):PX509_STORE; cdecl;
   TSslCtxCtrl = function(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: SslPtr): integer; cdecl;
   TSslNew = function(ctx: PSSL_CTX):PSSL; cdecl;
   TSslFree = procedure(ssl: PSSL); cdecl;
@@ -885,17 +953,28 @@ type
   TSslPending = function(ssl: PSSL):Integer; cdecl;
   TSslGetVersion = function(ssl: PSSL):PAnsiChar; cdecl;
   TSslGetPeerCertificate = function(ssl: PSSL):PX509; cdecl;
-  TSslCtxSetVerify = procedure(ctx: PSSL_CTX; mode: Integer; arg2: SslPtr); cdecl;
+  TSslCtxSetVerify = procedure(ctx: PSSL_CTX; mode: Integer;
+    arg2: TSSLVerifyCallback); cdecl;
   TSSLGetCurrentCipher = function(s: PSSL):SslPtr; cdecl;
   TSSLCipherGetName = function(c: Sslptr):PAnsiChar; cdecl;
   TSSLCipherGetBits = function(c: SslPtr; alg_bits: PInteger):Integer; cdecl;
   TSSLGetVerifyResult = function(ssl: PSSL):Integer; cdecl;
+  TSslGet0Param = function(ssl: PSSL):PX509_VERIFY_PARAM; cdecl;
   TSSLCtrl = function(ssl: PSSL; cmd: integer; larg: integer; parg: SslPtr):Integer; cdecl;
 
   TSSLSetTlsextHostName = function(ssl: PSSL; buf: PAnsiChar):Integer; cdecl;
 
 // libeay.dll
   TX509New = function: PX509; cdecl;
+  TX509StoreAddCert = function(Store: PX509_STORE; Cert: PX509):Integer; cdecl;
+  TX509StoreCtxGetCurrentCert = function(
+    StoreContext: PX509_STORE_CTX):PX509; cdecl;
+  TX509VerifyParamSetHostFlags = procedure(Param: PX509_VERIFY_PARAM;
+    Flags: Cardinal); cdecl;
+  TX509VerifyParamSet1Host = function(Param: PX509_VERIFY_PARAM;
+    Name: PAnsiChar; NameLen: SslSize):Integer; cdecl;
+  TX509VerifyParamSet1IPAsc = function(Param: PX509_VERIFY_PARAM;
+    IPAddress: PAnsiChar):Integer; cdecl;
   TX509NameOneline = function(a: PX509_NAME; buf: PAnsiChar; size: Integer):PAnsiChar; cdecl;
   TX509GetSubjectName = function(a: PX509):PX509_NAME; cdecl;
   TX509GetIssuerName = function(a: PX509):PX509_NAME; cdecl;
@@ -943,7 +1022,7 @@ type
   TAsn1IntegerSet = function(a: PASN1_INTEGER; v: integer): integer; cdecl;
   TAsn1IntegerGet = function(a: PASN1_INTEGER): integer; cdecl; {pf}
   Ti2dX509bio = function(b: PBIO; x: PX509): integer; cdecl;
-  Td2iX509bio = function(b:PBIO;  x:PX509):   PX509;   cdecl; {pf}
+  Td2iX509bio = function(b:PBIO;  x:PSslPtr):   PX509;   cdecl; {pf}
   TPEMReadBioX509 = function(b:PBIO;  {var x:PX509;}x:PSslPtr; callback:PFunction; cb_arg:SslPtr): PX509;   cdecl; {pf}
   TSkX509PopFree = procedure(st: PSTACK; func: TSkPopFreeFunc); cdecl; {pf}
   Ti2dPrivateKeyBio= function(b: PBIO; pkey: EVP_PKEY): integer; cdecl;
@@ -983,6 +1062,8 @@ var
   _SslCtxSetDefaultPasswdCb: TSslCtxSetDefaultPasswdCb = nil;
   _SslCtxSetDefaultPasswdCbUserdata: TSslCtxSetDefaultPasswdCbUserdata = nil;
   _SslCtxLoadVerifyLocations: TSslCtxLoadVerifyLocations = nil;
+  _SslCtxSetDefaultVerifyPaths: TSslCtxSetDefaultVerifyPaths = nil;
+  _SslCtxGetCertStore: TSslCtxGetCertStore = nil;
   _SslCtxCtrl: TSslCtxCtrl = nil;
   _SslNew: TSslNew = nil;
   _SslFree: TSslFree = nil;
@@ -1000,10 +1081,16 @@ var
   _SSLCipherGetName: TSSLCipherGetName = nil;
   _SSLCipherGetBits: TSSLCipherGetBits = nil;
   _SSLGetVerifyResult: TSSLGetVerifyResult = nil;
+  _SslGet0Param: TSslGet0Param = nil;
   _SSLCtrl: TSSLCtrl = nil;
 
 // libeay.dll
   _X509New: TX509New = nil;
+  _X509StoreAddCert: TX509StoreAddCert = nil;
+  _X509StoreCtxGetCurrentCert: TX509StoreCtxGetCurrentCert = nil;
+  _X509VerifyParamSetHostFlags: TX509VerifyParamSetHostFlags = nil;
+  _X509VerifyParamSet1Host: TX509VerifyParamSet1Host = nil;
+  _X509VerifyParamSet1IPAsc: TX509VerifyParamSet1IPAsc = nil;
   _X509NameOneline: TX509NameOneline = nil;
   _X509GetSubjectName: TX509GetSubjectName = nil;
   _X509GetIssuerName: TX509GetIssuerName = nil;
@@ -1268,6 +1355,22 @@ begin
     Result := 0;
 end;
 
+function SslCtxSetDefaultVerifyPaths(ctx: PSSL_CTX):Integer;
+begin
+  if InitSSLInterface and Assigned(_SslCtxSetDefaultVerifyPaths) then
+    Result := _SslCtxSetDefaultVerifyPaths(ctx)
+  else
+    Result := 0;
+end;
+
+function SslCtxGetCertStore(ctx: PSSL_CTX):PX509_STORE;
+begin
+  if InitSSLInterface and Assigned(_SslCtxGetCertStore) then
+    Result := _SslCtxGetCertStore(ctx)
+  else
+    Result := nil;
+end;
+
 function SslCtxCtrl(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: SslPtr): integer;
 begin
   if InitSSLInterface and Assigned(_SslCtxCtrl) then
@@ -1366,11 +1469,11 @@ begin
     Result := nil;
 end;
 
-//procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer; arg2: SslPtr);
-procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer; arg2: PFunction);
+procedure SslCtxSetVerify(ctx: PSSL_CTX; mode: Integer;
+  arg2: TSSLVerifyCallback);
 begin
   if InitSSLInterface and Assigned(_SslCtxSetVerify) then
-    _SslCtxSetVerify(ctx, mode, @arg2);
+    _SslCtxSetVerify(ctx, mode, arg2);
 end;
 
 function SSLGetCurrentCipher(s: PSSL):SslPtr;
@@ -1410,6 +1513,14 @@ begin
     Result := X509_V_ERR_APPLICATION_VERIFICATION;
 end;
 
+function SslGet0Param(ssl: PSSL):PX509_VERIFY_PARAM;
+begin
+  if InitSSLInterface and Assigned(_SslGet0Param) then
+    Result := _SslGet0Param(ssl)
+  else
+    Result := nil;
+end;
+
 
 function SSLCtrl(ssl: PSSL; cmd: integer; larg: integer; parg: SslPtr):Integer;
 begin
@@ -1432,6 +1543,47 @@ procedure X509Free(x: PX509);
 begin
   if InitSSLInterface and Assigned(_X509Free) then
     _X509Free(x);
+end;
+
+function X509StoreAddCert(Store: PX509_STORE; Cert: PX509):Integer;
+begin
+  if InitSSLInterface and Assigned(_X509StoreAddCert) then
+    Result := _X509StoreAddCert(Store, Cert)
+  else
+    Result := 0;
+end;
+
+function X509StoreCtxGetCurrentCert(StoreContext: PX509_STORE_CTX):PX509;
+begin
+  if InitSSLInterface and Assigned(_X509StoreCtxGetCurrentCert) then
+    Result := _X509StoreCtxGetCurrentCert(StoreContext)
+  else
+    Result := nil;
+end;
+
+procedure X509VerifyParamSetHostFlags(Param: PX509_VERIFY_PARAM;
+  Flags: Cardinal);
+begin
+  if InitSSLInterface and Assigned(_X509VerifyParamSetHostFlags) then
+    _X509VerifyParamSetHostFlags(Param, Flags);
+end;
+
+function X509VerifyParamSet1Host(Param: PX509_VERIFY_PARAM;
+  const Name: AnsiString; NameLen: SslSize):Integer;
+begin
+  if InitSSLInterface and Assigned(_X509VerifyParamSet1Host) then
+    Result := _X509VerifyParamSet1Host(Param, PAnsiChar(Name), NameLen)
+  else
+    Result := 0;
+end;
+
+function X509VerifyParamSet1IPAsc(Param: PX509_VERIFY_PARAM;
+  const IPAddress: AnsiString):Integer;
+begin
+  if InitSSLInterface and Assigned(_X509VerifyParamSet1IPAsc) then
+    Result := _X509VerifyParamSet1IPAsc(Param, PAnsiChar(IPAddress))
+  else
+    Result := 0;
 end;
 
 //function SslX509NameOneline(a: PX509_NAME; buf: PChar; size: Integer):PChar;
@@ -1741,10 +1893,10 @@ begin
     Result := 0;
 end;
 
-function d2iX509bio(b: PBIO; x: PX509): PX509; {pf}
+function d2iX509bio(b: PBIO; x: PSslPtr): PX509; {pf}
 begin
   if InitSSLInterface and Assigned(_d2iX509bio) then
-    Result := _d2iX509bio(x,b)
+    Result := _d2iX509bio(b,x)
   else
     Result := nil;
 end;
@@ -1856,6 +2008,31 @@ end;
 
 {$ENDIF}
 
+function SSLHostVerificationAvailable:Boolean;
+begin
+{$IFDEF CIL}
+  Result := True;
+{$ELSE}
+  Result := InitSSLInterface and Assigned(_SslCtxSetVerify)
+    and Assigned(_SslGet0Param)
+    and Assigned(_X509VerifyParamSetHostFlags)
+    and Assigned(_X509VerifyParamSet1Host)
+    and Assigned(_X509VerifyParamSet1IPAsc);
+{$ENDIF}
+end;
+
+function SSLWindowsCertificateVerificationAvailable:Boolean;
+begin
+{$IFDEF CIL}
+  Result := True;
+{$ELSE}
+  Result := InitSSLInterface and Assigned(_SslCtxSetVerify)
+    and Assigned(_SslCtxGetCertStore)
+    and Assigned(_X509StoreAddCert)
+    and Assigned(_X509StoreCtxGetCurrentCert);
+{$ENDIF}
+end;
+
 function LoadLib(const Value: String): HModule;
 begin
 {$IFDEF CIL}
@@ -1951,6 +2128,8 @@ begin
         _SslCtxSetDefaultPasswdCb := GetProcAddr(SSLLibHandle, 'SSL_CTX_set_default_passwd_cb');
         _SslCtxSetDefaultPasswdCbUserdata := GetProcAddr(SSLLibHandle, 'SSL_CTX_set_default_passwd_cb_userdata');
         _SslCtxLoadVerifyLocations := GetProcAddr(SSLLibHandle, 'SSL_CTX_load_verify_locations');
+        _SslCtxSetDefaultVerifyPaths := GetProcAddr(SSLLibHandle, 'SSL_CTX_set_default_verify_paths');
+        _SslCtxGetCertStore := GetProcAddr(SSLLibHandle, 'SSL_CTX_get_cert_store');
         _SslCtxCtrl := GetProcAddr(SSLLibHandle, 'SSL_CTX_ctrl');
         _SslNew := GetProcAddr(SSLLibHandle, 'SSL_new');
         _SslFree := GetProcAddr(SSLLibHandle, 'SSL_free');
@@ -1970,10 +2149,16 @@ begin
         _SslCipherGetName := GetProcAddr(SSLLibHandle, 'SSL_CIPHER_get_name');
         _SslCipherGetBits := GetProcAddr(SSLLibHandle, 'SSL_CIPHER_get_bits');
         _SslGetVerifyResult := GetProcAddr(SSLLibHandle, 'SSL_get_verify_result');
+        _SslGet0Param := GetProcAddr(SSLLibHandle, 'SSL_get0_param');
         _SslCtrl := GetProcAddr(SSLLibHandle, 'SSL_ctrl');
 
         _X509New := GetProcAddr(SSLUtilHandle, 'X509_new');
         _X509Free := GetProcAddr(SSLUtilHandle, 'X509_free');
+        _X509StoreAddCert := GetProcAddr(SSLUtilHandle, 'X509_STORE_add_cert');
+        _X509StoreCtxGetCurrentCert := GetProcAddr(SSLUtilHandle, 'X509_STORE_CTX_get_current_cert');
+        _X509VerifyParamSetHostFlags := GetProcAddr(SSLUtilHandle, 'X509_VERIFY_PARAM_set_hostflags');
+        _X509VerifyParamSet1Host := GetProcAddr(SSLUtilHandle, 'X509_VERIFY_PARAM_set1_host');
+        _X509VerifyParamSet1IPAsc := GetProcAddr(SSLUtilHandle, 'X509_VERIFY_PARAM_set1_ip_asc');
         _X509NameOneline := GetProcAddr(SSLUtilHandle, 'X509_NAME_oneline');
         _X509GetSubjectName := GetProcAddr(SSLUtilHandle, 'X509_get_subject_name');
         _X509GetIssuerName := GetProcAddr(SSLUtilHandle, 'X509_get_issuer_name');
@@ -2157,6 +2342,8 @@ begin
     _SslCtxSetDefaultPasswdCb := nil;
     _SslCtxSetDefaultPasswdCbUserdata := nil;
     _SslCtxLoadVerifyLocations := nil;
+    _SslCtxSetDefaultVerifyPaths := nil;
+    _SslCtxGetCertStore := nil;
     _SslCtxCtrl := nil;
     _SslNew := nil;
     _SslFree := nil;
@@ -2174,10 +2361,16 @@ begin
     _SslCipherGetName := nil;
     _SslCipherGetBits := nil;
     _SslGetVerifyResult := nil;
+    _SslGet0Param := nil;
     _SslCtrl := nil;
 
     _X509New := nil;
     _X509Free := nil;
+    _X509StoreAddCert := nil;
+    _X509StoreCtxGetCurrentCert := nil;
+    _X509VerifyParamSetHostFlags := nil;
+    _X509VerifyParamSet1Host := nil;
+    _X509VerifyParamSet1IPAsc := nil;
     _X509NameOneline := nil;
     _X509GetSubjectName := nil;
     _X509GetIssuerName := nil;


### PR DESCRIPTION
### Motivation
- Fix a security issue where HTTPS RPC connections did not validate the TLS certificate chain or server identity, allowing a man-in-the-middle attacker to capture Basic Auth credentials and spoof responses.
- Enable secure certificate and hostname verification without changing the existing user interface or configuration workflow.

### Description
- Enable `Http.Sock.SSL.VerifyCert := True` for HTTPS RPC connections.
- Configure OpenSSL's native pre-handshake DNS/IP identity verification through `SSL_get0_param` and `X509_VERIFY_PARAM_set1_host` / `X509_VERIFY_PARAM_set1_ip_asc`, reject partial wildcards, and omit SNI for IP literals.
- Apply hostname/IP verification when callers provide `SNIHost`, while preserving existing chain-only verification for non-HTTP Synapse clients that do not provide an identity host. HTTPS RPC always supplies the URL target host.
- Load default trust roots from OpenSSL's system paths on Unix only for client connections.
- On Windows, import trusted roots from the CurrentUser and LocalMachine ROOT stores and enforce both Disallowed stores for every certificate in the verified peer chain.
- Use CryptoAPI exact-certificate lookups for Windows distrust checks instead of repeatedly scanning entire stores.
- Fail closed when required OpenSSL verification APIs, Windows certificate stores, or trust roots are unavailable. On CIL, catch unavailable hostname-verification P/Invoke APIs at runtime and fail before the TLS handshake. Keep compatible OpenSSL 1.0.2 SONAME fallbacks while gating native behavior on the required runtime capabilities.

### Testing
- `lazbuild -B transgui.lpi` on Linux x86_64. (Passed)
- Full Lazarus cross-build for Windows i386 with the FPC 3.2.2 Win32 toolchain. (Passed; PE32 GUI executable verified)
- Full Lazarus cross-build for Windows x86_64 with the FPC 3.2.2 Win64 toolchain. (Passed; PE32+ GUI executable verified)
- Repeated all three builds sequentially after the final Windows root-EKU and scoped-IPv6 adjustments. (Passed; 22 existing warnings on each target)
- Ran a local TLS probe against a temporary trusted certificate: empty `SNIHost`, matching DNS SAN, and matching IP SAN succeeded; a mismatched hostname failed certificate verification.
- Fetched upstream and rebased onto the latest `master` before force-pushing; the branch was already up to date.
- Reviewed the final local diff with Claude, Kilo, OpenCode, Mimo, and an independent Codex reviewer; all reported no actionable issues. The final local CodeRabbit run was rate-limited, and Grok exited without substantive review output.
- GitHub checks completed with 15 successful and 0 failed checks; the PR-only release job was skipped and Cubic returned neutral after the branch rewrite. CodeRabbit completed without new inline findings, Kilo passed, and Qodo marked the scoped-IPv6 finding resolved. Qodo still suggests probing OpenSSL 0.9.8, but that runtime lacks the OpenSSL 1.0.2 hostname-verification APIs required by this security fix, so the suggestion was not applied. Copilot and `/agentic_review` were requested again for the final commit but produced no new review or inline comments after waiting more than ten minutes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a8ab1e0c8327bd31ed2b4c271296)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables full TLS certificate chain and hostname/IP verification for HTTPS RPC, auto-loading client trust roots and enforcing Windows trust/distrust policy. Drops OpenSSL 0.9.8 and fails closed when required verification features aren’t available.

- **Bug Fixes**
  - Turn on `Http.Sock.SSL.VerifyCert := True`; add pre-handshake DNS/IP checks via `SSL_get0_param` + `X509_VERIFY_PARAM_set1_host`/`_set1_ip_asc` with `NO_PARTIAL_WILDCARDS`; normalize scoped IPv6 and omit SNI for IP literals.
  - Auto-load trust roots for clients: Unix uses `SSL_CTX_set_default_verify_paths`; Windows imports `ROOT` from CurrentUser/LocalMachine, excludes `Disallowed`, requires `serverAuth` (or ANY) EKU, and requires at least one trusted root.
  - Enforce Windows distrust across the verified peer chain via an OpenSSL verify callback; surface clear errors using `X509_V_ERR_APPLICATION_VERIFICATION`.
  - Keep chain-only verification when no identity host is provided; HTTPS RPC always supplies the target host.

- **Dependencies**
  - Add OpenSSL bindings in `ssl_openssl_lib`: `SSL_CTX_set_default_verify_paths`, `SSL_CTX_get_cert_store`, `SSL_get0_param`, `X509_STORE_add_cert`, `X509_STORE_CTX_get_current_cert`, `X509_VERIFY_PARAM_set_hostflags`, `X509_VERIFY_PARAM_set1_host`, `X509_VERIFY_PARAM_set1_ip_asc`; update `SSL_CTX_set_verify` to use a typed `TSSLVerifyCallback`. Stop probing OpenSSL `0.9.8`.

<sup>Written for commit b2a084bd15252a1336b6dba7408bb67c195f01d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Enforced TLS certificate verification for HTTP connections.
  * When verification is enabled and no CA file is provided, default trust locations are now used (where supported).
  * Improved TLS host and IP verification on Windows, including clearer mapping of verification failures during connection and acceptance.

* **Compatibility / Robustness**
  * Added availability checks for advanced verification features and safe fallbacks when symbols aren’t present.
  * Tightened Windows certificate-store lifecycle handling and disallowed-certificate behavior.
  * Reduced OpenSSL library soname probing by removing the legacy `0.9.8` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->