### PR TITLE
Store the GeoIP download archive in the user directory

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -3086,7 +3086,7 @@ var
   i: integer;
 begin
   Result:=False;
-  tmp:=SysToUTF8(GetTempDir(True)) + 'GeoIP.dat.gz';
+  tmp:=FHomeDir + 'GeoIP.dat.gz';
   if not FileExistsUTF8(tmp) or AUpdate then begin
     if MessageDlg('', sGeoIPConfirm, mtConfirmation, mbYesNo, 0, mbYes) <> mrYes then
       exit;


### PR DESCRIPTION
### Motivation
- Fix the risk of local temporary-file poisoning caused by a predictable filename in a shared temporary directory. The previous path, such as `/tmp/GeoIP.dat.gz`, could be created in advance and then trusted by the application, potentially resulting in unsafe data import or disk exhaustion.

### Description
- Change the temporary archive path in `DownloadGeoIpDatabase` from `SysToUTF8(GetTempDir(True)) + 'GeoIP.dat.gz'` to `FHomeDir + 'GeoIP.dat.gz'`. Preserve the existing download, decompression, and cleanup flow to keep the behavior otherwise unchanged.

### Testing
- Ran `git diff --check` successfully to verify that the change introduces no whitespace errors.
- Used `python3` to verify that the temporary path was replaced in the source and no longer uses the fixed filename in the shared system temporary directory.
- Tried to run `make LAZARUS_DIR=/nonexistent all` as a full build check, but the build could not proceed because Lazarus is not available in the environment. The compilation test was therefore skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb9beed0832792f5debfd2097f23)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store the GeoIP download archive in the app’s user directory to avoid temp-file poisoning and disk exhaustion from predictable names in shared temp dirs. Download, decompress, and cleanup behavior remain unchanged.

- **Bug Fixes**
  - Write `GeoIP.dat.gz` to `FHomeDir` instead of `GetTempDir(True)`, avoiding shared dir risks like `/tmp`.

<sup>Written for commit 1e46cff5f828685c6c78b231143637cd86cc83ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoIP database download handling by storing the temporary archive in the application’s designated home directory.
  * Existing download and decompression behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->