### PR TITLE
Prevent Unbounded Folder Tree Expansion in Add Torrent

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -242,6 +242,25 @@ end;
 
 procedure TFilesTree.FillTree(ATorrentId: integer; files, priorities, wanted: TJSONArray);
 
+const
+  MaxFolderDepth = 64;
+  MaxFolderRows = 1024;
+  MaxFolderPathLength = 1024;
+
+  procedure _SetFileLevels(list: TVarList; const path: string; var idx: integer; cnt, level: integer);
+  var
+    s: string;
+  begin
+    while idx < cnt do begin
+      s:=StringReplace(UTF8Encode(widestring(list[idxFileFullPath, idx])), ':', '_', [rfReplaceAll, rfIgnoreCase]);
+      s:=ExtractFilePath(s);
+      if (path <> '') and (Pos(path, s) <> 1) then
+        break;
+      list[idxFileLevel, idx]:=level;
+      Inc(idx);
+    end;
+  end;
+
   procedure _AddFolders(list: TVarList; const path: string; var idx: integer; cnt, level: integer);
   var
     s, ss: string;
@@ -271,7 +290,14 @@ procedure TFilesTree.FillTree(ATorrentId: integer; files, priorities, wanted: TJ
         p:=PChar(ss);
         while (p^ <> #0) and not (p^ in ['/','\']) do
           Inc(p);
-        if p^ <> #0 then begin
+        if (p^ = #0) then begin
+          list[idxFileLevel, idx]:=level;
+          Inc(idx)
+        end
+        else if (level >= MaxFolderDepth) or (list.Count - cnt >= MaxFolderRows) or
+                (Length(path) + (p - PChar(ss) + 1) > MaxFolderPathLength) then
+          _SetFileLevels(list, path, idx, cnt, level)
+        else begin
           SetLength(ss, p - PChar(ss) + 1);
           j:=list.Count;
           list[idxFileLevel, j]:=level;


### PR DESCRIPTION
### Motivation

- Fix unbounded recursion and potential no-progress loops when Add Torrent builds synthetic folder rows from RPC or torrent filenames without limits on depth, row count, or path length. This prevents malicious filenames from causing a GUI denial of service.

### Description

- Add three protection constants in `TFilesTree.FillTree` in `addtorrent.pas`: `MaxFolderDepth`, `MaxFolderRows`, and `MaxFolderPathLength`, limiting synthetic folder recursion depth, added rows, and synthetic path length.
- Add the helper procedure `_SetFileLevels`, which flattens the remaining files at the current level when a limit is reached, preventing further synthetic folder rows from being created.
- Update the existing `_AddFolders` logic so that it sets the current level and increments `idx` when no separator is found, preventing a no-progress infinite loop. When any limit is exceeded, it calls `_SetFileLevels` and stops further recursion to prevent unbounded memory or stack growth.
- Preserve the existing display and level behavior, changing the expansion strategy only for extreme or malicious input to keep the UI responsive and secure.

### Testing

- Ran `git diff --check` and the syntax checks successfully.
- Ran the built-in Python assertion script to verify that `MaxFolderDepth`, `MaxFolderRows`, `MaxFolderPathLength`, `_SetFileLevels`, and the no-progress guard are present in the source code; verification passed.
- Attempted a full build, but the toolchain is unavailable in this environment: `fpc` and `lazbuild` are not installed, and `make -n LAZARUS_DIR=/nonexistent all` could not complete because the Lazarus directory was missing. Therefore, compilation and runtime automation tests could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb9ca4348327ba133c0bb35a1c0d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound folder tree growth in Add Torrent to prevent GUI freezes/DoS from malicious file names. Adds limits on depth, row count, and path length, guards against no-progress loops, and fixes path handling during flattening.

- **Bug Fixes**
  - Added `MaxFolderDepth`, `MaxFolderRows`, and `MaxFolderPathLength` in `TFilesTree.FillTree`.
  - Introduced `_SetFileLevels` to flatten remaining files at the current level when limits are hit; sanitizes `:` in paths to ensure correct prefix matching.
  - Updated `_AddFolders`: when no separator is found, set level and advance index; on limit exceed, flatten and stop recursion.

<sup>Written for commit cc2d9b1e9964e49410dc8c077138f3bf32bba8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested and large folder structures.
  * Added limits to prevent excessive folder expansion, overly long paths, and related display/performance issues.
  * When expansion caps are reached, remaining files and folders now receive appropriate levels so results stay consistent and usable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->