### PR TITLE
Prevent Torrent IPC Record Injection

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1170,12 +1170,20 @@ begin
   Result:=False;
 end;
 
+function HasIPCRecordDelimiter(const Value: string): boolean;
+begin
+  Result:=(Pos(#0, Value) > 0) or (Pos(#10, Value) > 0) or
+    (Pos(#13, Value) > 0);
+end;
+
 procedure AddTorrentFile(const FileName: string);
 var
   h: System.THandle;
   t: TDateTime;
   s: string;
 begin
+  if HasIPCRecordDelimiter(FileName) then
+    exit;
   if not IsProtocolSupported(FileName) and not FileExistsUTF8(FileName) then
     exit;
   t:=Now;
@@ -7896,6 +7904,7 @@ var
   i: integer;
   h: System.THandle;
   s: string;
+  sl: TStringList;
   WasHidden: boolean;
 begin
   h:=FileOpenUTF8(FIPCFileName, fmOpenRead or fmShareDenyWrite);
@@ -7915,7 +7924,13 @@ begin
       exit;
     end;
 
-    FPendingTorrents.Text:=FPendingTorrents.Text + s;
+    sl:=TStringList.Create;
+    try
+      sl.Text:=s;
+      FPendingTorrents.AddStrings(sl);
+    finally
+      sl.Free;
+    end;
   end;
 
   if FAddingTorrent <> 0 then
@@ -7966,6 +7981,8 @@ begin
     if not IsProtocolSupported(s) then
       exit;
     if (Pos('magnet:', LazUTF8.UTF8LowerCase(s)) <> 1) and (LazUTF8.UTF8LowerCase(Copy(s, Length(s) - Length(strTorrentExt) + 1, MaxInt)) <> strTorrentExt) then
+      exit;
+    if HasIPCRecordDelimiter(s) then
       exit;
 
     AddTorrentFile(s);


### PR DESCRIPTION
### Motivation

- Prevent torrent IPC record injection. Newline and NUL characters in a secondary instance’s torrent argument could otherwise create unintended pending entries, triggering remote URL requests or local file disclosure.

### Description

- Reject NUL, LF, and CR characters in `AddTorrentFile` before validation or IPC I/O.
- Retain the existing newline-delimited IPC format for compatibility with running older versions.
- Parse only newly received IPC text before appending it to `FPendingTorrents`, so paths already queued by the file dialog or local-folder watcher are not reserialized and split.
- Preserve automatically detected clipboard links when delimiter validation rejects them.

### Testing

- `git diff --check HEAD^ HEAD`
- Isolated Free Pascal regression test covering delimiter rejection, clipboard delimiter detection, multiple incoming records, record ordering, and preservation of an existing pending path containing LF.
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/2.0.0`
- `make -j2 zipdist`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb9c79148327ac507049b993a1a8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queued torrent additions by rejecting inputs containing invalid IPC record-delimiter characters.
  * Fixed queued-add processing by parsing the queued IPC data line-by-line.
  * Prevented malformed clipboard-based torrent requests from being enqueued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->