### PR TITLE
Fix macOS OpenURL Command Injection with TProcess

### DIFF
--- a/utils.pas
+++ b/utils.pas
@@ -447,6 +447,37 @@ begin
 end;
 {$endif unix}
 
+{$ifdef darwin}
+function DarwinOpenURL(const FileName: String): Integer;
+var
+  TargetName: String;
+  WrkProcess: TProcess;
+begin
+  Result:=-1;
+  TargetName:=FileName;
+  WrkProcess:=TProcess.Create(nil);
+  try
+    WrkProcess.Options:=[poNoConsole,poWaitOnExit];
+    WrkProcess.Executable:='/usr/bin/open';
+    if not FileExistsUTF8(WrkProcess.Executable) then
+      exit;
+    if TargetName <> '' then
+      if TargetName[1] = '-' then
+        TargetName:='./' + TargetName;
+    WrkProcess.Parameters.Add(TargetName);
+    try
+      WrkProcess.Execute;
+      Result:=WrkProcess.ExitStatus;
+    except
+      on EProcess do
+        Result:=-1;
+    end;
+  finally
+    WrkProcess.Free;
+  end;
+end;
+{$endif darwin}
+
 function OpenURL(const URL, Params: string): boolean;
 {$ifdef mswindows}
 var
@@ -463,7 +494,7 @@ begin
 {$endif mswindows}
 
 {$ifdef darwin}
-  Result:=fpSystem('open "' + URL + '"') = 0;
+  Result:=DarwinOpenURL(URL) = 0;
 {$else darwin}
 
   {$ifdef unix}


### PR DESCRIPTION
### Motivation

- Fix the command injection risk on macOS caused by the unescaped shell command `fpSystem('open "' + URL + '"')`.
- The root cause is that file or folder names originating from torrents or the daemon can be passed directly to an unescaped shell sink by user-triggered UI actions such as “Open Containing Folder”.

### Description

- Add `DarwinOpenURL` to `utils.pas`, using `TProcess` to execute `open` and pass the path as a separate argument, preventing shell interpolation.
- Use the canonical `/usr/bin/open` executable directly in `DarwinOpenURL` to avoid `PATH`-based resolution. If it is unavailable, return failure safely instead of falling back to the shell.
- Update the macOS branch of `OpenURL` to call `DarwinOpenURL(URL)`, removing the previous `fpSystem('open "' + URL + '"')` implementation.
- Limit these changes to `utils.pas` while preserving the existing behavior of waiting for the child process to exit and using its exit code to determine success.

### Testing

- Ran `git diff --check`; no style, merge-conflict, or other check errors were found.
- Attempted to run the `fpc` compilation check in the container, but Free Pascal is not installed in the environment, so the check was skipped due to this limitation.
- Used file search and `git diff` to verify that `fpSystem('open ...')` was removed and replaced with a `DarwinOpenURL` call, and that the changes were committed as a single commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a579051d75483279b54ad8c1f1bfcdf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS command injection by invoking `/usr/bin/open` with `TProcess` and passing the target as a single argument. Prefix option-like paths with `./` and keep existing success/failure behavior.

- **Bug Fixes**
  - Added `DarwinOpenURL` to run `/usr/bin/open` without a shell; passes the path as one argument and prefixes `./` if it starts with `-`.
  - Fails cleanly if `/usr/bin/open` is missing or the process can't launch; waits for exit and uses the child exit code; macOS `OpenURL` now calls `DarwinOpenURL` (changes limited to `utils.pas`).

<sup>Written for commit 2c0f3b13703e4d31453b4c4e1c8afc35bf7c7f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS URL handling to reliably open links, including those with special characters.
  * Added more robust behavior when the system URL opener is unavailable, including safer failure handling instead of relying on a shell-based command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->