### PR TITLE
Remove obsolete OpenSSL DLLs during upgrades

### DIFF
--- a/setup/win/setup.iss
+++ b/setup/win/setup.iss
@@ -176,6 +176,11 @@ begin
     VCVersionInstalled(VC_2013_REDIST_X86_ADD_40660)));
 end;
 
+function IsExistingInstallation: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{app}\{#AppExeName}'));
+end;
+
 
 procedure InitializeWizard();
 begin
@@ -186,6 +191,10 @@ begin
   end;
   idpDownloadAfter(wpReady);
 end;
+
+[InstallDelete]
+Type: files; Name: "{app}\libcrypto-1_1.dll"; Components: openssl; Check: IsExistingInstallation
+Type: files; Name: "{app}\libssl-1_1.dll"; Components: openssl; Check: IsExistingInstallation
 
 [Run]
 Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent

--- a/setup/win_amd64/setup.iss
+++ b/setup/win_amd64/setup.iss
@@ -178,6 +178,11 @@ begin
     VCVersionInstalled(VC_2013_REDIST_X86_ADD_40660)));
 end;
 
+function IsExistingInstallation: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{app}\{#AppExeName}'));
+end;
+
 
 procedure InitializeWizard();
 begin
@@ -188,6 +193,10 @@ begin
   end;
   idpDownloadAfter(wpReady);
 end;
+
+[InstallDelete]
+Type: files; Name: "{app}\libcrypto-1_1-x64.dll"; Components: openssl; Check: IsExistingInstallation
+Type: files; Name: "{app}\libssl-1_1-x64.dll"; Components: openssl; Check: IsExistingInstallation
 
 [Run]
 Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary

- remove the obsolete OpenSSL 1.1 DLL names during in-place upgrades
- require both an existing installation marker and the optional OpenSSL
  component selection before cleanup
- cover both Win32 and Win64 installer packages

## Why

The OpenSSL 3 update changed the bundled DLL filenames. Inno Setup does not
remove files whose destination names disappear from a later installer, so the
previous 1.1 DLLs otherwise remain after an upgrade.

Checking for the existing application executable limits deletion to an existing
installation, while the component condition preserves custom upgrades that
deselect bundled OpenSSL. A fresh install into a non-empty directory therefore
does not remove user-provided DLLs with the previous names.

## Validation

- compiled both installer scripts with Inno Setup 5.6.1
- exercised fresh and upgrade installs with the OpenSSL component selected and
  deselected
- verified fresh installs preserve pre-existing same-named DLLs
- verified CRLF-aware diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows installers now clean up legacy OpenSSL 1.1 DLLs during installation when the OpenSSL component is selected and a previous installation is detected, helping avoid conflicts with updated components.
  * Cleanup is applied for both the standard and 64-bit Windows installers to keep installed libraries consistent across installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->