### PR TITLE
Prefer x64 OpenSSL DLLs in 64-bit builds

### DIFF
--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -130,10 +130,17 @@ var
      {$ENDIF OS2}
     {$ENDIF}
   {$ELSE}
+  {$IFDEF WIN64}
+  DLLSSLName: string = 'libssl-3-x64.dll';
+  DLLSSLName2: string = 'libssl-3.dll';
+  DLLUtilName: string = 'libcrypto-3-x64.dll';
+  DLLUtilName2: string = 'libcrypto-3.dll';
+  {$ELSE}
   DLLSSLName: string = 'libssl-3.dll';
   DLLSSLName2: string = 'libssl-3-x64.dll';
   DLLUtilName: string = 'libcrypto-3.dll';
   DLLUtilName2: string = 'libcrypto-3-x64.dll';
+  {$ENDIF}
   {$ENDIF}
 {$ENDIF}
 
@@ -1890,10 +1897,28 @@ begin
       SSLUtilHandle := LoadLib(DLLUtilName);
       SSLLibHandle := LoadLib(DLLSSLName);
   {$IFDEF MSWINDOWS}
+    {$IFDEF WIN64}
+      if (SSLLibHandle = 0) or (SSLUtilHandle = 0) then
+      begin
+        if SSLLibHandle <> 0 then
+        begin
+          FreeLibrary(SSLLibHandle);
+          SSLLibHandle := 0;
+        end;
+        if SSLUtilHandle <> 0 then
+        begin
+          FreeLibrary(SSLUtilHandle);
+          SSLUtilHandle := 0;
+        end;
+        SSLUtilHandle := LoadLib(DLLUtilName2);
+        SSLLibHandle := LoadLib(DLLSSLName2);
+      end;
+    {$ELSE}
       if (SSLLibHandle = 0) then
         SSLLibHandle := LoadLib(DLLSSLName2);
       if (SSLUtilHandle = 0) then
         SSLUtilHandle := LoadLib(DLLUtilName2);
+    {$ENDIF}
   {$ENDIF}
 {$ENDIF}
       if (SSLLibHandle <> 0) and (SSLUtilHandle <> 0) then
@@ -2062,7 +2087,7 @@ begin
 {$IFNDEF CIL}
           FreeLibrary(SSLUtilHandle);
 {$ENDIF}
-          SSLLibHandle := 0;
+          SSLUtilHandle := 0;
         end;
         Result := False;
       end;


### PR DESCRIPTION
## Summary

- prefer the x64-suffixed OpenSSL DLL names in native Win64 builds
- retry the unsuffixed fallback names as a matching pair when either preferred
  DLL cannot be loaded
- clear released handles when a complete fallback pair cannot be loaded
- preserve the existing Win32 load order and public overrides

## Why

The Win64 installer ships `libssl-3-x64.dll` and `libcrypto-3-x64.dll`, but the
loader tried the unsuffixed names first. A compatible DLL with an unsuffixed
name could therefore be selected before the bundled and tested x64 copy.

Retrying both fallback names together prevents the loader from retaining one
preferred DLL while falling back only the other half of the pair. Correctly
clearing a released crypto handle also keeps failed initialization safe for
later cleanup.

## Validation

- completed full Win32 and Win64 Lazarus cross-builds
- verified Win32 and Win64 OpenSSL 3.5.7 runtime loading
- verified Win64 prefers the bundled x64 files in the presence of valid
  unsuffixed decoys
- verified a partial preferred pair falls back to matching unsuffixed DLLs
- verified a partial fallback failure leaves both library handles cleared
- verified CRLF-aware diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenSSL/crypto library detection on Windows 64-bit by prioritizing the correct 64-bit DLL names for loading.
  * Updated fallback behavior to load both SSL and util DLLs together when primary loading partially fails.
  * Fixed cleanup logic to ensure the correct util DLL handle is properly reset on shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->