### PR TITLE
Harden macOS DMG creation against transient detach failures

### DIFF
--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -ex
 
 prog_ver="$(cat ../../VERSION.txt)"
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD ../..)"
@@ -9,9 +9,68 @@ fpc_ver="$(fpc -i V | head -n 1)"
 exename=../../transgui
 appname="Transmission Remote GUI"
 dmg_dist_file="../../Release/transgui-$prog_ver.dmg"
+dmg_temp_file="$dmg_dist_file.tmp.dmg"
 dmgfolder=./Release
 appfolder="$dmgfolder/$appname.app"
 lazdir="${1:-/Library/Lazarus/}"
+mount_device=""
+remove_dmg_temp=0
+remove_dmgfolder=0
+remove_tmp_dmg=0
+
+detach_disk_image() {
+  detach_device=$1
+  detach_attempt=1
+
+  sync
+  while ! hdiutil detach "$detach_device"; do
+    if [ "$detach_attempt" -ge 5 ]; then
+      echo "Failed to detach $detach_device after $detach_attempt attempts." >&2
+      return 1
+    fi
+
+    echo "Failed to detach $detach_device; retrying in 2 seconds." >&2
+    sleep 2
+    detach_attempt=$((detach_attempt + 1))
+  done
+}
+
+cleanup() {
+  status=$?
+  cleanup_status=0
+
+  trap '' HUP INT TERM
+  trap - 0
+  set +e
+
+  if [ -n "$mount_device" ]; then
+    detach_status=0
+    detach_disk_image "$mount_device" || detach_status=$?
+    if [ "$detach_status" -eq 0 ]; then
+      mount_device=""
+    else
+      cleanup_status=$detach_status
+      remove_tmp_dmg=0
+    fi
+  fi
+  if [ "$remove_dmg_temp" -eq 1 ]; then
+    rm -f "$dmg_temp_file" || cleanup_status=$?
+  fi
+  if [ "$remove_tmp_dmg" -eq 1 ]; then
+    rm -f tmp.dmg || cleanup_status=$?
+  fi
+  if [ "$remove_dmgfolder" -eq 1 ]; then
+    rm -rf "$dmgfolder" || cleanup_status=$?
+  fi
+  if [ -e ../../about.lfm.bak ]; then
+    mv ../../about.lfm.bak ../../about.lfm || cleanup_status=$?
+  fi
+
+  if [ "$status" -eq 0 ]; then
+    status=$cleanup_status
+  fi
+  exit "$status"
+}
 
 if [ -z "${CI-}" ]; then
   ./install_deps.sh
@@ -20,6 +79,22 @@ fi
 if [ ! "$lazdir" = "" ]; then
   lazdir=LAZARUS_DIR="$lazdir"
 fi
+
+if [ -e ../../about.lfm.bak ]; then
+  echo "../../about.lfm.bak already exists; refusing to overwrite it." >&2
+  exit 1
+fi
+if [ -e "$dmg_dist_file" ] && [ ! -f "$dmg_dist_file" ]; then
+  echo "$dmg_dist_file exists and is not a regular file." >&2
+  exit 1
+fi
+if [ -e "$dmg_temp_file" ] && [ ! -f "$dmg_temp_file" ]; then
+  echo "$dmg_temp_file exists and is not a regular file." >&2
+  exit 1
+fi
+
+trap cleanup 0
+trap 'exit 1' HUP INT TERM
 
 mkdir -p ../../Release/
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" ../../about.lfm
@@ -36,6 +111,7 @@ if ! [ -e $exename ]; then
 fi
 strip "$exename"
 
+remove_dmgfolder=1
 rm -rf "$appfolder"
 
 echo "Creating $appfolder..."
@@ -55,20 +131,39 @@ sed -e "s/@prog_ver@/$prog_ver/" Info.plist > "$appfolder/Contents/Info.plist"
 ln -s /Applications "$dmgfolder/Drag \"Transmission Remote GUI\" here!"
 
 hdiutil create -ov -anyowners -volname "transgui-v$prog_ver" -format UDRW -srcfolder ./Release -fs HFS+ "tmp.dmg"
+remove_tmp_dmg=1
 
-mount_device="$(hdiutil attach -readwrite -noautoopen "tmp.dmg" | awk 'NR==1{print$1}')"
-mount_volume="$(mount | grep "$mount_device" | sed 's/^[^ ]* on //;s/ ([^)]*)$//')"
+remove_tmp_dmg=0
+attach_status=0
+attach_output="$(hdiutil attach -readwrite -noautoopen "tmp.dmg")" || attach_status=$?
+mount_device="$(printf '%s\n' "$attach_output" | awk 'NR == 1 && $1 ~ /^\/dev\/disk[0-9]+(s[0-9]+)*$/ {print $1}')"
+if [ -z "$mount_device" ]; then
+  echo "Failed to determine the mounted disk image device." >&2
+  if [ "$attach_status" -ne 0 ]; then
+    exit "$attach_status"
+  fi
+  exit 1
+fi
+remove_tmp_dmg=1
+if [ "$attach_status" -ne 0 ]; then
+  exit "$attach_status"
+fi
+mount_volume="$(printf '%s\n' "$attach_output" | awk -F '\t' 'NF >= 3 && $NF ~ /^\// {volume=$NF} END {print volume}')"
+if [ -z "$mount_volume" ]; then
+  echo "Failed to determine the mounted disk image volume." >&2
+  exit 1
+fi
 cp transgui.icns "$mount_volume/.VolumeIcon.icns"
 SetFile -c icnC "$mount_volume/.VolumeIcon.icns"
 SetFile -a C "$mount_volume"
 
-hdiutil detach "$mount_device"
-rm -f "$dmg_dist_file"
-hdiutil convert tmp.dmg -format UDBZ -imagekey zlib-level=9 -o "$dmg_dist_file"
-
-rm tmp.dmg
-rm -rf "$dmgfolder"
-mv ../../about.lfm.bak ../../about.lfm
+detach_disk_image "$mount_device"
+mount_device=""
+remove_dmg_temp=1
+rm -f "$dmg_temp_file"
+hdiutil convert tmp.dmg -format UDBZ -imagekey zlib-level=9 -o "$dmg_temp_file"
+mv -f "$dmg_temp_file" "$dmg_dist_file"
+remove_dmg_temp=0
 
 if [ -z "${CI-}" ]; then
   open "$dmg_dist_file"


### PR DESCRIPTION
## Summary

- retry transient `hdiutil detach` failures before converting the disk image
- propagate packaging failures while restoring modified sources and cleaning up only artifacts owned by the current run
- preserve the backing image when an attached device cannot be identified or safely detached
- convert into a temporary DMG and replace the final artifact only after conversion succeeds

## Root cause

The DMG packaging script continued after `hdiutil detach` failed with `Resource busy`. The subsequent conversion also failed, but the script still completed successfully, so the missing artifact was only detected by the checksum step.

## Validation

- `sh -n setup/macosx/create_app_new.sh`
- `shellcheck setup/macosx/create_app_new.sh`
- `shfmt -sr -i 2 -d -ci setup/macosx/create_app_new.sh`
- `git diff --check`
- stubbed shell checks for retry exhaustion, cleanup status propagation, mounted backing-image preservation, and partial attach failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened macOS DMG packaging to handle transient attach/detach errors and fail fast on real failures. Prevents missing or partial DMG artifacts and ensures safe cleanup with atomic publish.

- **Bug Fixes**
  - Retry `hdiutil detach` up to 5 times (2s delay) and run `sync` first.
  - Enable `set -ex` with trap-based cleanup that propagates exit codes, restores `about.lfm`, and removes only this run’s artifacts.
  - Parse `hdiutil attach` output robustly; require both device and volume; propagate attach errors; preserve the backing image if it can’t be safely detached.
  - Convert to a temp DMG and atomically replace the final artifact only on success; validate inputs (executable exists; refuse to overwrite `about.lfm.bak`; ensure final and temp DMG paths are regular files).

<sup>Written for commit c2fe1451bee0d2e7b14dd2cc922d114ae2dc15c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS DMG packaging reliability with stricter pre-flight validation for expected DMG paths, files, and existing backup artifacts.
  * Added safer disk image attach/detach handling, including retrying detachment and more reliable detection of the mounted device/volume.
  * Deferred restoration of `about.lfm` from its backup to a centralized cleanup flow for more consistent outcomes.
* **Chores / Maintenance**
  * Added trap-based cleanup to remove temporary DMG artifacts and packaging leftovers on normal completion, with clearer failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->