### PR TITLE
Prune Stale Tracker Entries When Grouping Is Disabled

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -6321,26 +6321,38 @@ begin
 
     row:=j;
 
+    j:=0;
+    while (j < FTrackers.Count) and (ptruint(FTrackers.Objects[j]) > 0) do
+      Inc(j);
+    if j < FTrackers.Count then begin
+      FTrackers.BeginUpdate;
+      try
+        for i:=j + 1 to FTrackers.Count - 1 do
+          if ptruint(FTrackers.Objects[i]) > 0 then begin
+            FTrackers.Exchange(i, j);
+            Inc(j);
+          end;
+        for i:=FTrackers.Count - 1 downto j do
+          FTrackers.Delete(i);
+      finally
+        FTrackers.EndUpdate;
+      end;
+    end;
+
     if acTrackerGrouping.Checked then begin
       if not VarIsNull(lvFilter.Items[0, row - 1]) then begin
         lvFilter.Items[0, row]:=NULL;
         Inc(row);
       end;
 
-      i:=0;
-      while i < FTrackers.Count do begin
+      for i:=0 to FTrackers.Count - 1 do begin
         j:=ptruint(FTrackers.Objects[i]);
-        if j > 0 then begin
-          lvFilter.Items[ 0, row]:=UTF8Decode(Format('%s (%d)', [FTrackers[i], j]));
-          lvFilter.Items[-1, row]:=NULL;
-          lvFilter.Items[-2, row]:=3;
-          if FTrackers[i] = TrackerFilter then
-            crow:=row;
-          Inc(i);
-          Inc(row);
-        end
-        else
-          FTrackers.Delete(i);
+        lvFilter.Items[ 0, row]:=UTF8Decode(Format('%s (%d)', [FTrackers[i], j]));
+        lvFilter.Items[-1, row]:=NULL;
+        lvFilter.Items[-2, row]:=3;
+        if FTrackers[i] = TrackerFilter then
+          crow:=row;
+        Inc(row);
       end;
     end;
 


### PR DESCRIPTION
### Motivation

- Fix a usability issue where zero-count (stale) entries in `FTrackers` were not removed when tracker grouping was disabled, causing the cache to grow without bounds. If RPC responses are controlled or compromised and continuously return different tracker names, this could lead to memory exhaustion.

### Description

- Add a cleanup loop in the `FillTorrentsList` rendering flow in `main.pas` to remove all entries in `FTrackers` with a count of zero before tracker groups are displayed. This ensures that stale tracker entries are pruned regardless of whether tracker grouping is enabled.
- Preserve the existing tracker grouping behavior; when `acTrackerGrouping.Checked` is true, tracker rows are formatted and added to `lvFilter` as before.
- Limit the changes to the relevant section of `main.pas` by inserting the cleanup loop between filter-row population and tracker display logic. No external APIs or UI settings persistence behavior are changed.

### Testing

- Used Python assertions against the source code to verify that the cleanup loop appears before the tracker display check; all assertions passed.
- Ran `git diff --check`; no patch formatting or whitespace errors were reported.
- Attempted `make -n all` to validate the build configuration, but it failed because Lazarus is not installed or configured. The `Makefile` requires `LAZARUS_DIR=<dir>`, so native compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a8d70ec9083278fa84c0d1c90dfd9)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prune and compact stale tracker entries in `FTrackers` even when tracker grouping is hidden to stop unbounded growth and OOM. Cleanup preserves live entry order and runs in linear time.

- **Bug Fixes**
  - Compact `FTrackers` in `FillTorrentsList` by moving live entries forward and deleting trailing stale ones before the grouping check.
  - Build tracker rows with a `for` loop; no in-loop deletions.
  - Change only `main.pas`; no API or settings changes.

<sup>Written for commit b0c3a651d5b696cde7a097ee334d7672899e4183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped tracker filter behavior by cleaning up invalid tracker entries before rendering the tracker filter rows.
  * Ensured the tracker list and the currently selected tracker filter are populated consistently when tracker grouping is enabled, avoiding gaps or mismatched selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->