### PR TITLE
Handle Missing Torrent Fields for Each Torrent

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -870,7 +870,8 @@ const
   idxDeleted = -5;
   idxDownSpeedHistory = -6;
   idxUpSpeedHistory = -7;
-  TorrentsExtraColumns = 7;
+  idxLabelsData = -8;
+  TorrentsExtraColumns = 8;
 
   // Peers list
   idxPeerHost = 0;
@@ -1718,6 +1719,10 @@ begin
                 LocalWatchTimer.Interval:=trunc(Ini.ReadFloat('Interface','WatchInterval',1)*60000);
                 LocalWatchTimer.Enabled := true;
             end;
+  acFolderGrouping.Checked:=Ini.ReadBool('Interface', 'FolderGrouping', True);
+  acLabelGrouping.Checked:=Ini.ReadBool('Interface', 'LabelGrouping', True);
+  acTrackerGrouping.Checked:=Ini.ReadBool('Interface', 'TrackerGrouping', True);
+
   LoadColumns(gTorrents, 'TorrentsList');
   TorrentColumnsChanged;
   LoadColumns(lvFiles, 'FilesList');
@@ -1745,9 +1750,6 @@ begin
 
   bidiMode := GetBiDi;
 
-  acFolderGrouping.Checked:=Ini.ReadBool('Interface', 'FolderGrouping', True);
-  acLabelGrouping.Checked:=Ini.ReadBool('Interface', 'LabelGrouping', True);
-  acTrackerGrouping.Checked:=Ini.ReadBool('Interface', 'TrackerGrouping', True);
   FLinksFromClipboard:=Ini.ReadBool('Interface', 'LinksFromClipboard', True);
   Application.OnActivate:=@FormActivate;
   Application.OnException:=@ApplicationPropertiesException;
@@ -2065,7 +2067,7 @@ procedure TMainForm.acLabelGroupingExecute(Sender: TObject);
 begin
   acLabelGrouping.Checked:=not acLabelGrouping.Checked;
   Ini.WriteBool('Interface', 'LabelGrouping', acLabelGrouping.Checked);
-  RpcObj.RefreshNow:=RpcObj.RefreshNow + [rtTorrents];
+  TorrentColumnsChanged;
 end;
 
 procedure TMainForm.acMenuShowExecute(Sender: TObject);
@@ -3140,6 +3142,11 @@ begin
           s:=s + TorrentFieldsMap[ID - 1];
         end;
       end;
+  if acLabelGrouping.Checked and (Pos('labels', s) = 0) then begin
+    if s <> '' then
+      s:=s + ',';
+    s:=s + 'labels';
+  end;
   RpcObj.TorrentFields:=s;
   DoRefresh(True);
 end;
@@ -5744,11 +5751,11 @@ end;
 
 procedure TMainForm.FillTorrentsList(list: TJSONArray);
 var
-  i, j, p, row, crow, id, StateImg: integer;
+  i, j, row, crow, id, StateImg: integer;
   t: TJSONObject;
   a: TJSONArray;
   f: double;
-  ExistingRow: boolean;
+  ExistingRow, NoTracker: boolean;
   s, ss: string;
 
   function GetTorrentValue(AIndex: integer; const AName: string; AType: integer): boolean;
@@ -5839,6 +5846,17 @@ var
   Paths, Labels: TStringList;
   v: variant;
   FieldExists: array of boolean;
+
+  procedure AddLabel(const ALabel: string);
+  var
+    p: integer;
+  begin
+    p:=Labels.IndexOf(ALabel);
+    if p < 0 then
+      Labels.AddObject(ALabel, TObject(1))
+    else
+      Labels.Objects[p]:=TObject(PtrInt(Labels.Objects[p]) + 1);
+  end;
 begin
   if gTorrents.Tag <> 0 then exit;
   if list = nil then begin
@@ -5879,20 +5897,7 @@ begin
   for i:=0 to FTrackers.Count - 1 do
     FTrackers.Objects[i]:=nil;
 
-  // Check fields' existence
   SetLength(FieldExists, FTorrents.ColCnt);
-  if list.Count > 0 then begin
-    t:=list[0] as TJSONObject;
-    FieldExists[idxName]:=t.IndexOfName('name') >= 0;
-    FieldExists[idxRatio]:=t.IndexOfName('uploadRatio') >= 0;
-    FieldExists[idxTracker]:=t.IndexOfName('trackers') >= 0;
-    FieldExists[idxPath]:=t.IndexOfName('downloadDir') >= 0;
-    FieldExists[idxPriority]:=t.IndexOfName('bandwidthPriority') >= 0;
-    FieldExists[idxQueuePos]:=t.IndexOfName('queuePosition') >= 0;
-    FieldExists[idxSeedingTime]:=t.IndexOfName('secondsSeeding') >= 0;
-    FieldExists[idxPrivate]:=t.IndexOfName('isPrivate') >= 0;
-    FIeldExists[idxLabels]:=t.IndexOfName('labels') >= 0;
-  end;
 
   UpSpeed:=0;
   DownSpeed:=0;
@@ -5931,6 +5936,16 @@ begin
     StateImg:=-1;
 
     t:=list[i] as TJSONObject;
+    // Check optional fields' existence for the current torrent.
+    FieldExists[idxName]:=t.IndexOfName('name') >= 0;
+    FieldExists[idxRatio]:=t.IndexOfName('uploadRatio') >= 0;
+    FieldExists[idxTracker]:=t.IndexOfName('trackers') >= 0;
+    FieldExists[idxPath]:=t.IndexOfName('downloadDir') >= 0;
+    FieldExists[idxPriority]:=t.IndexOfName('bandwidthPriority') >= 0;
+    FieldExists[idxQueuePos]:=t.IndexOfName('queuePosition') >= 0;
+    FieldExists[idxSeedingTime]:=t.IndexOfName('secondsSeeding') >= 0;
+    FieldExists[idxPrivate]:=t.IndexOfName('isPrivate') >= 0;
+    FieldExists[idxLabels]:=t.IndexOfName('labels') >= 0;
     id:=t.Integers['id'];
     ExistingRow:=FTorrents.Find(idxTorrentId, id, row);
     if not ExistingRow then
@@ -6071,22 +6086,33 @@ begin
     else
       FTorrents[idxSeedingTime, row]:=NULL;
 
+    NoTracker:=False;
     if RpcObj.RPCVersion >= 7 then begin
       if t.Arrays['trackerStats'].Count > 0 then
         s:=t.Arrays['trackerStats'].Objects[0].Strings['announce']
-      else
-        s:=sNoTracker;
+      else begin
+        s:='';
+        NoTracker:=True;
+      end;
     end
     else
-      if FieldExists[idxTracker] then
-        s:=UTF8Encode(t.Arrays['trackers'].Objects[0].Strings['announce'])
+      if FieldExists[idxTracker] then begin
+        if t.Arrays['trackers'].Count > 0 then
+          s:=UTF8Encode(t.Arrays['trackers'].Objects[0].Strings['announce'])
+        else begin
+          s:='';
+          NoTracker:=True;
+        end;
+      end
       else begin
         s:='';
         if VarIsEmpty(FTorrents[idxTracker, row]) then
           RpcObj.RequestFullInfo:=True;
       end;
 
-    if s <> '' then begin
+    if NoTracker then
+      FTorrents[idxTracker, row]:=UTF8Decode(sNoTracker)
+    else if s <> '' then begin
       j:=Pos('://', s);
       if j > 0 then
         s:=Copy(s, j + 3, MaxInt);
@@ -6138,18 +6164,25 @@ begin
 
     if FieldExists[idxLabels] then begin
       a := t.Arrays['labels'];
+      FTorrents[idxLabelsData, row] := a.AsJSON;
       s := '';
       for j:=0 to a.Count-1 do begin
         ss := UTF8Encode(widestring(a.Strings[j]));
         if j > 0 then s := s + ', ';
         s := s + ss;
-        p := Labels.IndexOf(ss);
-        if p < 0 then
-          Labels.AddObject(ss, TObject(1))
-        else
-          Labels.Objects[p]:=TObject(PtrInt(Labels.Objects[p]) + 1);
+        AddLabel(ss);
       end;
       FTorrents[idxLabels, row] := s;
+    end
+    else if acLabelGrouping.Checked and
+            not VarIsEmpty(FTorrents[idxLabelsData, row]) then begin
+      a:=GetJSON(UTF8Encode(widestring(FTorrents[idxLabelsData, row]))) as TJSONArray;
+      try
+        for j:=0 to a.Count - 1 do
+          AddLabel(UTF8Encode(widestring(a.Strings[j])));
+      finally
+        a.Free;
+      end;
     end;
 
     DownSpeed:=DownSpeed + FTorrents[idxDownSpeed, row];
@@ -6212,8 +6245,9 @@ begin
       if (PathFilter <> '') and not VarIsEmpty(FTorrents[idxPath, i]) and (UTF8Decode(PathFilter) <> FTorrents[idxPath, i]) then
         continue;
 
-      if (LabelFilter <> '') and not VarIsEmpty(FTorrents[idxLabels, i]) then begin
-        if not AnsiContainsStr(String(FTorrents[idxLabels, i]), LabelFilter) then
+      if LabelFilter <> '' then begin
+        if VarIsEmpty(FTorrents[idxLabels, i]) or VarIsNull(FTorrents[idxLabels, i]) or
+           not AnsiContainsStr(String(FTorrents[idxLabels, i]), LabelFilter) then
           continue;
       end;
 
@@ -6248,7 +6282,8 @@ begin
       if not gTorrents.Items.Find(idxTorrentId, FTorrents[idxTorrentId, i], row) then
         gTorrents.Items.InsertRow(row);
       for j:=-TorrentsExtraColumns to FTorrents.ColCnt - 1 do
-        if (j <> idxDownSpeedHistory) and (j <> idxUpSpeedHistory) then
+        if (j <> idxDownSpeedHistory) and (j <> idxUpSpeedHistory) and
+           (j <> idxLabelsData) then
           gTorrents.Items[j, row]:=FTorrents[j, i];
       gTorrents.Items[idxTag, row]:=1;
     end;
@@ -6391,6 +6426,7 @@ begin
         [RpcObj.InfoStatus, LineEnding, DownCnt, SeedCnt, LineEnding, StatusBar.Panels[1].Text, StatusBar.Panels[2].Text]);
 {$endif LCLcarbon}
   finally
+    Labels.Free;
     Paths.Free;
   end;
   DetailsUpdated;


### PR DESCRIPTION
### Motivation

- Transmission-compatible RPC responses can omit optional fields for individual torrents. Treating the first torrent as the schema for the whole response can either read missing values from later torrents or ignore values that are present only on later torrents, interrupting or corrupting GUI refresh state.
- Partial refreshes also need to preserve label grouping data, while empty tracker arrays must be distinguished from omitted tracker fields.

### Description

- Check optional field availability for each torrent before reading its name, ratio, tracker, path, priority, queue position, seeding time, privacy flag, or labels.
- Cache each torrent's labels as JSON so grouping counts can be rebuilt when a partial response omits `labels`; request `labels` whenever label grouping is enabled and refresh the requested field set when that preference changes.
- Exclude torrents with missing or empty labels from an active label filter.
- Handle empty `trackerStats` and legacy `trackers` arrays as "no tracker" without indexing the first element, while preserving cached tracker data when the field itself is omitted.
- Load grouping preferences before deriving the requested torrent fields and keep the internal label cache out of the visible grid.

### Testing

- `git diff --check`
- FPC 3.0.4 / Lazarus 2.0.0: `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/`
- FPC 3.0.4 / Lazarus 2.0.0: `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ all`
- FPC 3.0.4 / Lazarus 2.0.0: `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ zipdist`
- Linux GTK2/Xvfb smoke test: opened and closed the startup, GeoIP confirmation, main, and application-options windows, then exited normally.
- Mock RPC 15 test: put a torrent with missing optional fields before torrents that provide them and verified that later values still render without an error dialog.
- Stateful mock RPC 16 test: returned labels on the first full refresh and omitted them on subsequent refreshes; cached labels and grouping counts remained intact, including comma-containing, Traditional Chinese, and emoji labels.
- Mock RPC 6 test: returned an empty legacy `trackers` array and verified repeated refreshes without an exception or error dialog.
- Compared merge-base and PR-head updates with 1,000, 5,000, and 10,000 mock torrents at a one-second refresh interval. No repeatable PR-specific regression was observed. Both versions were dominated by existing synchronous grid work at larger sizes (about 17-18 seconds per 5,000-torrent refresh and more than 90 seconds for the first 10,000-torrent UI update in this environment).
- All current GitHub Actions build, static, package-smoke, and test checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb9caa7c83279f0ffbca3aa2fa78)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GUI refresh crashes and inconsistent grouping by handling missing vs empty torrent fields per item and caching label data for stable rebuilds. Tracker and label grouping stay correct across partial RPC responses, and unlabeled torrents are skipped when a label filter is active.

- **Bug Fixes**
  - Check optional fields per torrent after `t := list[i]`, and distinguish missing fields from empty values; remove the first-item cache.
  - Preserve label grouping: add `idxLabelsData`, store labels JSON per row, request `labels` when grouping is on, rebuild counts on partial refreshes, and exclude unlabeled torrents from active filters.
  - Handle trackers safely: treat empty/missing arrays as “no tracker”, avoid bounds errors, and keep host parsing intact.
  - Initialize grouping options at startup and route the label-grouping toggle through `TorrentColumnsChanged`; avoid copying hidden `idxLabelsData` to the grid.

<sup>Written for commit 0f6e946655ac9c8cb3e341f23141a2f9f8eeb73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent list handling when optional details vary between torrents.
  * Improved tracker information retrieval when tracker data is unavailable or empty.
  * Enhanced label grouping so columns and counts update correctly, including partial responses.
  * Improved filtering to safely handle torrents with empty label values.
  * Prevented cached label data from appearing in visible torrent rows.

* **Maintenance**
  * Improved grouping initialization and cleanup for more consistent list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
