### PR TITLE
Restrict RPC Redirects to Root-Relative Paths

### DIFF
--- a/rpc.pas
+++ b/rpc.pas
@@ -926,7 +926,7 @@ begin
 
         if Http.ResultCode = 301 then begin
           s:=Trim(Http.Headers.Values['Location']);
-          if (s <> '') and (i = 1) then begin
+          if (s <> '') and (Copy(s, 1, 1) = '/') and (Copy(s, 1, 2) <> '//') and (i = 1) then begin
             j:=Length(s);
             if Copy(s, j - 4, MaxInt) = '/web/' then
               SetLength(s, j - 4)


### PR DESCRIPTION
### Motivation

- Prevent redirects caused by an untrusted `Location` header from sending RPC requests to arbitrary hosts (SSRF/retargeting risk). Only restricted root-relative paths should be accepted as the source for discovering custom Transmission RPC paths.

### Description

- Add validation to the 301 redirect handling in `rpc.pas` so that a `Location` value is accepted as a path only when it is non-empty, begins with exactly one `/`, and is not a `//` network-path reference. Preserve the existing behavior of removing a trailing `/web` or `/web/` and appending `rpc`.

### Testing

- Ran a dedicated Free Pascal predicate harness with both complete (`{$B+}{$R+}`) and short-circuit (`{$B-}{$R+}`) Boolean evaluation; accepted root-relative paths and rejected empty, `@host:...`, absolute, `//host`, ordinary relative, and later-attempt values as expected.
- Ran `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/` with Lazarus 2.0 and Free Pascal 3.0.4 in a Debian Buster container; completed successfully.
- Ran `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ all` in the same environment; completed successfully.
- Ran `git diff --check`; no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb9c42788327b5bfc35b01729a7e)



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP 301 redirects to safely process valid relative paths.
  * Prevented unintended rewrites for protocol-relative or invalid redirect locations.
