### PR TITLE
Validate UI scaling loaded from configuration

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1219,6 +1219,13 @@ begin
 end;
 end;
 
+function ReadIntfScale(ADefault: integer): integer;
+begin
+  Result:=Ini.ReadInteger('Interface', 'Scaling', ADefault);
+  if (Result < 10) or (Result > 200) then
+    Result:=ADefault;
+end;
+
 function CheckAppParams: boolean;
 var
   i: integer;
@@ -1339,7 +1346,7 @@ begin
   SizeNames[4]:=sGByte;
   SizeNames[5]:=sTByte;
 
-  IntfScale:=Ini.ReadInteger('Interface', 'Scaling', 100);
+  IntfScale:=ReadIntfScale(100);
 
   Result:=True;
 end;
@@ -2221,7 +2228,7 @@ begin
     cbShowAddTorrentWindow.Checked:=Ini.ReadBool('Interface', 'ShowAddTorrentWindow', True);
     cbDeleteTorrentFile.Checked:=Ini.ReadBool('Interface', 'DeleteTorrentFile', False);
     cbLinksFromClipboard.Checked:=Ini.ReadBool('Interface', 'LinksFromClipboard', True);
-    edIntfScale.Value:=Ini.ReadInteger('Interface', 'Scaling', 100);
+    edIntfScale.Value:=ReadIntfScale(IntfScale);
     cbCheckNewVersion.Checked:=Ini.ReadBool('Interface', 'CheckNewVersion', False);
     edCheckVersionDays.Value:=Ini.ReadInteger('Interface', 'CheckNewVersionDays', 5);
     cbCheckNewVersionClick(nil);


### PR DESCRIPTION
### Motivation

- Prevent invalid `Interface.Scaling` values from reaching startup scaling calculations.
- Preserve lower scaling values that the DPI-adjusted Options control already permits.

### Description

- Read UI scaling through a shared validator that accepts values from `10` through `200` and falls back to a safe caller-provided value.
- Use `100` at startup and the active scale when opening Options, while preserving valid saved values that are pending a restart.
- Leave invalid settings untouched until the user saves Options.

### Testing

- `git diff --check origin/master..HEAD`
- Boundary checks for invalid, endpoint, high-DPI, and pending-restart values
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/` with FPC 3.0.4 and Lazarus 2.0.0 in Debian Buster
- `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ all`
- `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ zipdist`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a91bc70808327a9c47ed71b0533af)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the UI scaling value loaded from the INI (`Interface.Scaling`) to 75–200 to prevent invalid values causing crashes or incorrect rendering. This aligns startup validation with the options dialog `TSpinEdit` limits and avoids divide-by-zero and overflow.

<sup>Written for commit 3cb742f46321a1a9abeacf41ed460593c4d488e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
