### PR TITLE
Fix quick-search selection when match is at starting row

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -128,7 +128,7 @@ type
     procedure DoCellAttributes(Sender: TVarGrid; ACol, ARow, ADataCol: integer; AState: TGridDrawState; var CellAttribs: TCellAttributes);
     procedure DoCheckBoxClick(Sender: TVarGrid; ACol, ARow, ADataCol: integer);
     procedure DoDrawCell(Sender: TVarGrid; ACol, ARow, ADataCol: integer; AState: TGridDrawState; const R: TRect; var ADefaultDrawing: boolean);
-    procedure DoQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer);
+    procedure DoQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer; var Found: boolean);
     procedure DoTreeButtonClick(Sender: TVarGrid; ACol, ARow, ADataCol: integer);
     procedure DoAfterSort(Sender: TObject);
     procedure ExpandFolder(ARow: integer);
@@ -858,12 +858,13 @@ begin
   end;
 end;
 
-procedure TFilesTree.DoQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer);
+procedure TFilesTree.DoQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer; var Found: boolean);
 var
   i: integer;
   s: string;
   v: variant;
 begin
+  Found:=False;
   s:= LazUTF8.UTF8UpperCase(SearchText);
   for i:=ARow to Sender.Items.Count - 1 do begin
     v:=Sender.Items[idxFileName, i];
@@ -871,6 +872,7 @@ begin
       continue;
     if Pos(s, Trim(LazUTF8.UTF8UpperCase((widestring(v))))) > 0 then begin
       ARow:=i;
+      Found:=True;
       EnsureRowVisible(ARow);
       break;
     end;

--- a/main.pas
+++ b/main.pas
@@ -626,7 +626,7 @@ type
     procedure gTorrentsDrawCell(Sender: TVarGrid; ACol, ARow, ADataCol: integer; AState: TGridDrawState; const R: TRect; var ADefaultDrawing: boolean);
     procedure gTorrentsEditorHide(Sender: TObject);
     procedure gTorrentsEditorShow(Sender: TObject);
-    procedure gTorrentsQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer);
+    procedure gTorrentsQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer; var Found: boolean);
     procedure gTorrentsResize(Sender: TObject);
     procedure gTorrentsSetEditText(Sender: TObject; ACol, ARow: Integer; const Value: string);
     procedure gTorrentsSortColumn(Sender: TVarGrid; var ASortCol: integer);
@@ -4562,12 +4562,13 @@ begin
   gTorrents.RemoveSelection;
 end;
 
-procedure TMainForm.gTorrentsQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer);
+procedure TMainForm.gTorrentsQuickSearch(Sender: TVarGrid; var SearchText: string; var ARow: integer; var Found: boolean);
 var
   i: integer;
   s: string;
   v: variant;
 begin
+  Found:=False;
   s:=UTF8UpperCase(SearchText);
   for i:=ARow to gTorrents.Items.Count - 1 do begin
     v:=gTorrents.Items[idxName, i];
@@ -4575,6 +4576,7 @@ begin
       continue;
     if Pos(s, Trim(UTF8UpperCase(UTF8Encode(widestring(v))))) > 0 then begin
       ARow:=i;
+      Found:=True;
       break;
     end;
   end;

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -56,7 +56,7 @@ type
   TOnDrawCellEvent = procedure (Sender: TVarGrid; ACol, ARow, ADataCol: integer; AState: TGridDrawState; const R: TRect; var ADefaultDrawing: boolean) of object;
   TOnSortColumnEvent = procedure (Sender: TVarGrid; var ASortCol: integer) of object;
   TCellNotifyEvent = procedure (Sender: TVarGrid; ACol, ARow, ADataCol: integer) of object;
-  TOnQuickSearch = procedure (Sender: TVarGrid; var SearchText: string; var ARow: integer) of object;
+  TOnQuickSearch = procedure (Sender: TVarGrid; var SearchText: string; var ARow: integer; var Found: boolean) of object;
 
   { TVarGridStringEditor }
 
@@ -901,6 +901,7 @@ end;
 procedure TVarGrid.UTF8KeyPress(var UTF8Key: TUTF8Char);
 var
   i, r: integer;
+  Found: boolean;
 begin
   inherited UTF8KeyPress(UTF8Key);
   if UTF8Key = #0 then
@@ -914,8 +915,9 @@ begin
   FCurSearch:=FCurSearch + UTF8Key;
   if Assigned(FOnQuickSearch) then begin
     r:=i;
-    FOnQuickSearch(Self, FCurSearch, r);
-    if r <> i then
+    Found:=False;
+    FOnQuickSearch(Self, FCurSearch, r, Found);
+    if Found then
       Row:=r;
   end
   else begin


### PR DESCRIPTION
### Motivation
- Fix quick search with a custom `OnQuickSearch` callback incorrectly treating a match at the starting row, such as row 0, as no match and leaving the selection unchanged.

### Description
- Extend `TOnQuickSearch` with an explicit `var Found: boolean` result so `TVarGrid.UTF8KeyPress` updates `Row` only when the callback reports a match.
- Update both in-repository handlers, `TMainForm.gTorrentsQuickSearch` and `TFilesTree.DoQuickSearch`, to initialize `Found` and set it when a matching row is found.

### Testing
- `git diff --check`
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/`
- `make -j2 zipdist`
- GitHub Actions CI: static checks, zip tarball smoke test, Linux builds for x86_64, i686, armv6l, and armv7l, and the macOS DMG build

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a900c60c48327a8325b367d108fee)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix quick-search selection when the first row matches by adding an explicit `Found` flag to the callback. This prevents false “no match” and updates the selected row correctly across torrents and the file tree.

- **Bug Fixes**
  - Extend `TOnQuickSearch` to `(...; var ARow: integer; var Found: boolean)`.
  - In `TVarGrid.UTF8KeyPress`, move `Row` only when `Found` is true.
  - Update `gTorrentsQuickSearch` and `TFilesTree.DoQuickSearch` to set `Found := True` on match; ensure row visibility in the file tree.

- **Migration**
  - Update any `OnQuickSearch` handler to accept `var Found: boolean` and set it to true when a match is found.

<sup>Written for commit 2f7c1d10d5a4c6fbe10db3f0e5bbae14c8f8f79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quick search behavior by accurately detecting when a matching result is found.
  - Updated result selection so the highlighted row moves only when a valid match exists.
  - Prevented incorrect row navigation when searches do not produce a match.
  - Applied consistent match detection across torrent and file searches.
  - Made search feedback more reliable when moving through results, especially when no matching item is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->