### PR TITLE
Prevent stale RPC cleanup from corrupting concurrent requests

### DIFF
--- a/rpc.pas
+++ b/rpc.pas
@@ -976,13 +976,15 @@ begin
         end;
         Http.Document.Position:=0;
         jp:=CreateJsonParser(Http);
+        { Clear under HttpLock before another request can reuse the shared HTTP
+          document buffer; the parser has read all response data it needs. }
+        Http.Document.Clear;
         HttpLock.Leave;
         locked:=False;
         RequestStartTime:=0;
         try
           try
             obj:=jp.Parse;
-            Http.Document.Clear;
           finally
             jp.Free;
           end;


### PR DESCRIPTION
## Summary

- Prevent a completed RPC request from clearing the shared HTTP document after a concurrent request has begun reusing it.
- Keep response-buffer cleanup inside HttpLock while preserving JSON parsing outside the critical section.

## Why

UI actions and background polling can call SendRequest concurrently through the same HTTP client. Clearing its shared document after releasing HttpLock allowed an earlier request to erase or corrupt a later request's request body or response.

TJSONParser copies the response data during construction, so the shared buffer can be cleared safely before unlocking without extending the critical section through JSON parsing.

## Validation

- Built the application and release archive.
- Verified parsing remains valid after the source stream is cleared or released.