### PR TITLE
Load matching OpenSSL libraries on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
     runs-on: macos-15-intel
     needs: static
     env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
       sourceforge_mirror: pilotfiber
 
     steps:
@@ -256,8 +257,14 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
+          brew install openssl@3
           cd setup/macosx
           ./install_deps.sh
+
+      - name: Verify OpenSSL loading
+        run: |
+          set -euo pipefail
+          ./setup/macosx/tests/verify_openssl_loader.sh "$(brew --prefix openssl@3)"
 
       - name: Build DMG
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
     runs-on: macos-15-intel
     needs: static
     env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
       sourceforge_mirror: pilotfiber
 
     steps:
@@ -263,8 +264,14 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
+          brew install openssl@3
           cd setup/macosx
           ./install_deps.sh
+
+      - name: Verify OpenSSL loading
+        run: |
+          set -euo pipefail
+          ./setup/macosx/tests/verify_openssl_loader.sh "$(brew --prefix openssl@3)"
 
       - name: Build DMG
         run: |

--- a/README.md
+++ b/README.md
@@ -95,17 +95,37 @@ Run `choco install transgui` to install the latest version of Transmission Remot
 
 #### Without a package manager
 
-This method requires no additional prerequisites or dependencies:
+This installation method does not require a package manager:
 
 1. Download the disk image from the release page.
 2. Open the image file to mount the image.
 3. Directly run the application or drag the app icon to your disk / Applications folder.
+
+The disk image does not bundle OpenSSL. HTTPS RPC connections require a
+compatible OpenSSL installation. For new installations, use OpenSSL 3 from
+Homebrew (`brew install openssl@3`) or MacPorts (`sudo port install openssl3`).
+On Apple Silicon, MacPorts must use the `+universal` variant for the current
+x86_64 disk image
+(`sudo port install openssl3 +universal`). Existing OpenSSL 1.1 installations
+are detected for compatibility, but OpenSSL 1.1 is end-of-life and is not
+recommended for new installations.
+
+OpenSSL must match the application's CPU architecture. The current disk image
+contains an x86_64 application, so Apple Silicon users need Rosetta 2 and an
+x86_64 or universal OpenSSL build, such as Intel Homebrew installed under
+`/usr/local`. The arm64 libraries installed by native Homebrew under
+`/opt/homebrew` cannot be loaded by the current disk image. Native arm64 builds
+prefer `/opt/homebrew` but can also use compatible Homebrew libraries under
+`/usr/local/opt`.
 
 #### Homebrew
 
 You need to have [Homebrew](https://brew.sh/) installed. Execute this command to install Transmission Remote GUI:
 
 - `brew install --cask transmission-remote-gui`
+
+The cask does not bundle OpenSSL. HTTPS RPC connections have the same OpenSSL
+and CPU architecture requirements described above.
 
 ## Command line parameters
 

--- a/README.md
+++ b/README.md
@@ -94,17 +94,37 @@ Run `choco install transgui` to install the latest version of Transmission Remot
 
 #### Without a package manager
 
-This method requires no additional prerequisites or dependencies:
+This installation method does not require a package manager:
 
 1. Download the disk image from the release page.
 2. Open the image file to mount the image.
 3. Directly run the application or drag the app icon to your disk / Applications folder.
+
+The disk image does not bundle OpenSSL. HTTPS RPC connections require a
+compatible OpenSSL installation. For new installations, use OpenSSL 3 from
+Homebrew (`brew install openssl@3`) or MacPorts (`sudo port install openssl3`).
+On Apple Silicon, MacPorts must use the `+universal` variant for the current
+x86_64 disk image
+(`sudo port install openssl3 +universal`). Existing OpenSSL 1.1 installations
+are detected for compatibility, but OpenSSL 1.1 is end-of-life and is not
+recommended for new installations.
+
+OpenSSL must match the application's CPU architecture. The current disk image
+contains an x86_64 application, so Apple Silicon users need Rosetta 2 and an
+x86_64 or universal OpenSSL build, such as Intel Homebrew installed under
+`/usr/local`. The arm64 libraries installed by native Homebrew under
+`/opt/homebrew` cannot be loaded by the current disk image. Native arm64 builds
+prefer `/opt/homebrew` but can also use compatible Homebrew libraries under
+`/usr/local/opt`.
 
 #### Homebrew
 
 You need to have [Homebrew](https://brew.sh/) installed. Execute this command to install Transmission Remote GUI:
 
 - `brew install --cask transmission-remote-gui`
+
+The cask does not bundle OpenSSL. HTTPS RPC connections have the same OpenSSL
+and CPU architecture requirements described above.
 
 ## Command line parameters
 

--- a/main.pas
+++ b/main.pas
@@ -5173,7 +5173,11 @@ begin
     RpcObj.Http.Sock.SSL.PFXfile:=Ini.ReadString(Sec, 'CertFile', '');
     RpcObj.Http.Sock.SSL.KeyPassword:=DecodeBase64(Ini.ReadString(Sec, 'CertPass', ''));
     if not IsSSLloaded then begin
+{$ifdef darwin}
+      MessageDlg(Format(sSSLLoadError, [FirstTriedDLLSSLName, FirstTriedDLLUtilName]), mtError, [mbOK], 0);
+{$else}
       MessageDlg(Format(sSSLLoadError, [DLLSSLName, DLLUtilName]), mtError, [mbOK], 0);
+{$endif}
       exit;
     end;
     RpcObj.Url:='https';

--- a/readme.txt
+++ b/readme.txt
@@ -87,13 +87,33 @@ Using Chocolatey.
 MACOS:
 
 Without a package manager.
-This method requires no additional prerequisites or dependencies:
+This installation method does not require a package manager:
   1. Download the disk image from the release page.
   2. Open the image file to mount the image.
   3. Directly run the application or drag the app icon to your disk / Applications folder.
 
+The disk image does not bundle OpenSSL. HTTPS RPC connections require a
+compatible OpenSSL installation. For new installations, use OpenSSL 3 from
+Homebrew ("brew install openssl@3") or MacPorts ("sudo port install openssl3").
+On Apple Silicon, MacPorts must use the "+universal" variant for the current
+x86_64 disk image
+("sudo port install openssl3 +universal"). Existing OpenSSL 1.1 installations
+are detected for compatibility, but OpenSSL 1.1 is end-of-life and is not
+recommended for new installations.
+
+OpenSSL must match the application's CPU architecture. The current disk image
+contains an x86_64 application, so Apple Silicon users need Rosetta 2 and an
+x86_64 or universal OpenSSL build, such as Intel Homebrew installed under
+"/usr/local". The arm64 libraries installed by native Homebrew under
+"/opt/homebrew" cannot be loaded by the current disk image. Native arm64 builds
+prefer "/opt/homebrew" but can also use compatible Homebrew libraries under
+"/usr/local/opt".
+
 Using Homebrew.
 - You need to have Homebrew installed. Execute this command to install Transmission Remote GUI: "brew install --cask transmission-remote-gui"
+
+The cask does not bundle OpenSSL. HTTPS RPC connections have the same OpenSSL
+and CPU architecture requirements described above.
 
 COMMAND LINE PARAMETERS
 

--- a/readme.txt
+++ b/readme.txt
@@ -90,13 +90,33 @@ Using Chocolatey.
 MACOS:
 
 Without a package manager.
-This method requires no additional prerequisites or dependencies:
+This installation method does not require a package manager:
   1. Download the disk image from the release page.
   2. Open the image file to mount the image.
   3. Directly run the application or drag the app icon to your disk / Applications folder.
 
+The disk image does not bundle OpenSSL. HTTPS RPC connections require a
+compatible OpenSSL installation. For new installations, use OpenSSL 3 from
+Homebrew ("brew install openssl@3") or MacPorts ("sudo port install openssl3").
+On Apple Silicon, MacPorts must use the "+universal" variant for the current
+x86_64 disk image
+("sudo port install openssl3 +universal"). Existing OpenSSL 1.1 installations
+are detected for compatibility, but OpenSSL 1.1 is end-of-life and is not
+recommended for new installations.
+
+OpenSSL must match the application's CPU architecture. The current disk image
+contains an x86_64 application, so Apple Silicon users need Rosetta 2 and an
+x86_64 or universal OpenSSL build, such as Intel Homebrew installed under
+"/usr/local". The arm64 libraries installed by native Homebrew under
+"/opt/homebrew" cannot be loaded by the current disk image. Native arm64 builds
+prefer "/opt/homebrew" but can also use compatible Homebrew libraries under
+"/usr/local/opt".
+
 Using Homebrew.
 - You need to have Homebrew installed. Execute this command to install Transmission Remote GUI: "brew install --cask transmission-remote-gui"
+
+The cask does not bundle OpenSSL. HTTPS RPC connections have the same OpenSSL
+and CPU architecture requirements described above.
 
 COMMAND LINE PARAMETERS
 

--- a/rpc.pas
+++ b/rpc.pas
@@ -219,8 +219,19 @@ begin
       InitSSLInterface;
     end;
     Result:=IsSSLloaded;
+{$ifdef darwin}
+    if not Result then begin
+      ASSLName:=FirstTriedDLLSSLName;
+      AUtilName:=FirstTriedDLLUtilName;
+    end
+    else begin
+      ASSLName:=DLLSSLName;
+      AUtilName:=DLLUtilName;
+    end;
+{$else}
     ASSLName:=DLLSSLName;
     AUtilName:=DLLUtilName;
+{$endif darwin}
   finally
     OpenSSLInitLock.Leave;
   end;

--- a/setup/macosx/tests/openssl_loader_probe.pas
+++ b/setup/macosx/tests/openssl_loader_probe.pas
@@ -1,0 +1,174 @@
+program openssl_loader_probe;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils, ssl_openssl_lib;
+
+procedure Fail(const MessageText: string);
+begin
+  WriteLn(StdErr, MessageText);
+  Halt(1);
+end;
+
+var
+  Context: PSSL_CTX;
+  ConfiguredUtilName, ConfiguredSSLName: string;
+{$IFDEF DARWIN}
+  ExpectedFirstUtilFile, ExpectedFirstSSLFile: string;
+{$ENDIF}
+  ExpectedLibDir, ExpectedUtilFile, ExpectedSSLFile, VersionText: string;
+  ExpectFailure, Loaded: Boolean;
+  Method: PSSL_METHOD;
+begin
+  if (ParamCount < 1) or (ParamCount > 2) then
+    Fail('Usage: openssl_loader_probe <OpenSSL prefix> [override|invalid-override]');
+
+  ExpectFailure := False;
+  ExpectedLibDir := ExpandFileName(
+    IncludeTrailingPathDelimiter(ParamStr(1)) + 'lib');
+  ExpectedUtilFile := IncludeTrailingPathDelimiter(ExpectedLibDir) +
+    'libcrypto.3.dylib';
+  ExpectedSSLFile := IncludeTrailingPathDelimiter(ExpectedLibDir) +
+    'libssl.3.dylib';
+{$IFDEF DARWIN}
+  {$IFDEF CPUAARCH64}
+  ExpectedFirstUtilFile :=
+    '/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib';
+  ExpectedFirstSSLFile := '/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib';
+  {$ELSE}
+  ExpectedFirstUtilFile := '/usr/local/opt/openssl@3/lib/libcrypto.3.dylib';
+  ExpectedFirstSSLFile := '/usr/local/opt/openssl@3/lib/libssl.3.dylib';
+  {$ENDIF}
+{$ENDIF}
+  if ParamCount = 2 then
+  begin
+    if (ParamStr(2) <> 'override') and
+      (ParamStr(2) <> 'invalid-override') then
+      Fail('Unknown mode: ' + ParamStr(2));
+    DLLUtilName := ExpectedUtilFile;
+    if ParamStr(2) = 'invalid-override' then
+    begin
+      DLLSSLName := ExpectedLibDir + '/missing/libssl.3.dylib';
+      ExpectFailure := True;
+    end
+    else
+      DLLSSLName := ExpectedSSLFile;
+{$IFDEF DARWIN}
+    ExpectedFirstUtilFile := DLLUtilName;
+    ExpectedFirstSSLFile := DLLSSLName;
+{$ENDIF}
+  end;
+  ConfiguredUtilName := DLLUtilName;
+  ConfiguredSSLName := DLLSSLName;
+  Loaded := InitSSLInterface;
+{$IFDEF DARWIN}
+  if DLLUtilName <> ConfiguredUtilName then
+    Fail('Configured libcrypto name changed: ' + DLLUtilName);
+  if DLLSSLName <> ConfiguredSSLName then
+    Fail('Configured libssl name changed: ' + DLLSSLName);
+{$ENDIF}
+  if ExpectFailure then
+  begin
+    if Loaded then
+      Fail('Invalid OpenSSL override unexpectedly loaded');
+{$IFDEF DARWIN}
+    if FirstTriedDLLUtilName <> DLLUtilName then
+      Fail('Unexpected first attempted libcrypto: ' + FirstTriedDLLUtilName);
+    if FirstTriedDLLSSLName <> DLLSSLName then
+      Fail('Unexpected first attempted libssl: ' + FirstTriedDLLSSLName);
+    if LastTriedDLLUtilName <> DLLUtilName then
+      Fail('Unexpected last attempted libcrypto: ' + LastTriedDLLUtilName);
+    if LastTriedDLLSSLName <> DLLSSLName then
+      Fail('Unexpected last attempted libssl: ' + LastTriedDLLSSLName);
+{$ENDIF}
+    if (SSLUtilHandle <> 0) or (SSLLibHandle <> 0) then
+      Fail('OpenSSL handles remain after a failed override');
+    if InitSSLInterface then
+      Fail('Invalid OpenSSL override unexpectedly loaded on retry');
+{$IFDEF DARWIN}
+    if FirstTriedDLLUtilName <> DLLUtilName then
+      Fail('Unexpected first retried libcrypto: ' + FirstTriedDLLUtilName);
+    if FirstTriedDLLSSLName <> DLLSSLName then
+      Fail('Unexpected first retried libssl: ' + FirstTriedDLLSSLName);
+    if LastTriedDLLUtilName <> DLLUtilName then
+      Fail('Unexpected last retried libcrypto: ' + LastTriedDLLUtilName);
+    if LastTriedDLLSSLName <> DLLSSLName then
+      Fail('Unexpected last retried libssl: ' + LastTriedDLLSSLName);
+{$ENDIF}
+    if (SSLUtilHandle <> 0) or (SSLLibHandle <> 0) then
+      Fail('OpenSSL handles remain after a failed override retry');
+    Exit;
+  end;
+  if not Loaded then
+    Fail('OpenSSL failed to load');
+  if ExpandFileName(ExtractFileDir(SSLUtilFile)) <> ExpectedLibDir then
+    Fail('Unexpected libcrypto path: ' + SSLUtilFile);
+  if ExpandFileName(ExtractFileDir(SSLLibFile)) <> ExpectedLibDir then
+    Fail('Unexpected libssl path: ' + SSLLibFile);
+  if ExtractFileName(SSLUtilFile) <> ExtractFileName(ExpectedUtilFile) then
+    Fail('Unexpected libcrypto file: ' + SSLUtilFile);
+  if ExtractFileName(SSLLibFile) <> ExtractFileName(ExpectedSSLFile) then
+    Fail('Unexpected libssl file: ' + SSLLibFile);
+{$IFDEF DARWIN}
+  if FirstTriedDLLUtilName <> ExpectedFirstUtilFile then
+    Fail('Unexpected first attempted libcrypto: ' + FirstTriedDLLUtilName);
+  if FirstTriedDLLSSLName <> ExpectedFirstSSLFile then
+    Fail('Unexpected first attempted libssl: ' + FirstTriedDLLSSLName);
+  if LastTriedDLLUtilName <> SSLUtilFile then
+    Fail('Unexpected last attempted libcrypto: ' + LastTriedDLLUtilName);
+  if LastTriedDLLSSLName <> SSLLibFile then
+    Fail('Unexpected last attempted libssl: ' + LastTriedDLLSSLName);
+{$ENDIF}
+
+  VersionText := SSLeayversion(0);
+  if Pos('OpenSSL 3', VersionText) <> 1 then
+    Fail('Unexpected OpenSSL version: ' + VersionText);
+  Method := SslMethodTLS;
+  if Method = nil then
+    Fail('TLS_method is unavailable');
+  Context := SslCtxNew(Method);
+  if Context = nil then
+    Fail('SSL_CTX_new failed');
+  SslCtxFree(Context);
+  WriteLn('Loaded ', VersionText);
+  WriteLn('libcrypto: ', SSLUtilFile);
+  WriteLn('libssl: ', SSLLibFile);
+
+  if not DestroySSLInterface then
+    Fail('OpenSSL cleanup failed');
+  if (SSLUtilHandle <> 0) or (SSLLibHandle <> 0) then
+    Fail('OpenSSL handles remain after cleanup');
+  SSLUtilFile := '';
+  SSLLibFile := '';
+{$IFDEF DARWIN}
+  FirstTriedDLLUtilName := 'stale libcrypto path';
+  FirstTriedDLLSSLName := 'stale libssl path';
+{$ENDIF}
+  if not InitSSLInterface then
+    Fail('OpenSSL failed to reload');
+{$IFDEF DARWIN}
+  if (DLLUtilName <> ConfiguredUtilName) or
+    (DLLSSLName <> ConfiguredSSLName) then
+    Fail('Configured OpenSSL names changed after reload');
+  if FirstTriedDLLUtilName <> ExpectedFirstUtilFile then
+    Fail('Unexpected first reloaded libcrypto: ' + FirstTriedDLLUtilName);
+  if FirstTriedDLLSSLName <> ExpectedFirstSSLFile then
+    Fail('Unexpected first reloaded libssl: ' + FirstTriedDLLSSLName);
+  if LastTriedDLLUtilName <> SSLUtilFile then
+    Fail('Unexpected last reloaded libcrypto: ' + LastTriedDLLUtilName);
+  if LastTriedDLLSSLName <> SSLLibFile then
+    Fail('Unexpected last reloaded libssl: ' + LastTriedDLLSSLName);
+{$ENDIF}
+  if ExpandFileName(SSLUtilFile) <> ExpectedUtilFile then
+    Fail('Unexpected reloaded libcrypto: ' + SSLUtilFile);
+  if ExpandFileName(SSLLibFile) <> ExpectedSSLFile then
+    Fail('Unexpected reloaded libssl: ' + SSLLibFile);
+  VersionText := SSLeayversion(0);
+  if Pos('OpenSSL 3', VersionText) <> 1 then
+    Fail('Unexpected reloaded OpenSSL version: ' + VersionText);
+  if not DestroySSLInterface then
+    Fail('OpenSSL reload cleanup failed');
+  if (SSLUtilHandle <> 0) or (SSLLibHandle <> 0) then
+    Fail('OpenSSL handles remain after reload cleanup');
+end.

--- a/setup/macosx/tests/verify_openssl_loader.sh
+++ b/setup/macosx/tests/verify_openssl_loader.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <OpenSSL prefix>" >&2
+  exit 2
+fi
+
+root_dir="$(cd -P -- "$(dirname "$0")/../../.." && pwd)"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/transgui-openssl-loader.XXXXXX")"
+
+cleanup() {
+  rm -rf "$build_dir"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+mkdir -p "$build_dir/units"
+mkdir -p "$build_dir/override/lib"
+ln -s "$1/lib/libcrypto.3.dylib" \
+  "$build_dir/override/lib/libcrypto.3.dylib"
+ln -s "$1/lib/libssl.3.dylib" \
+  "$build_dir/override/lib/libssl.3.dylib"
+fpc -B \
+  -Fu"$root_dir/synapse/source/lib" \
+  -FE"$build_dir" \
+  -FU"$build_dir/units" \
+  "$root_dir/setup/macosx/tests/openssl_loader_probe.pas"
+"$build_dir/openssl_loader_probe" "$1"
+"$build_dir/openssl_loader_probe" "$build_dir/override" override
+"$build_dir/openssl_loader_probe" "$build_dir/override" invalid-override

--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -110,11 +110,20 @@ const
   DLLUtilName = 'libcrypto-1_1.dll';
   {$ENDIF}
 {$ELSE}
+  {$IFDEF DARWIN}
+const
+  DarwinDefaultDLLSSLName = 'libssl.3.dylib';
+  DarwinDefaultDLLUtilName = 'libcrypto.3.dylib';
+  {$ENDIF}
 var
   {$IFNDEF MSWINDOWS}
     {$IFDEF DARWIN}
-    DLLSSLName: string = 'libssl.dylib';
-    DLLUtilName: string = 'libcrypto.dylib';
+    DLLSSLName: string = DarwinDefaultDLLSSLName;
+    DLLUtilName: string = DarwinDefaultDLLUtilName;
+    FirstTriedDLLSSLName: string = DarwinDefaultDLLSSLName;
+    FirstTriedDLLUtilName: string = DarwinDefaultDLLUtilName;
+    LastTriedDLLSSLName: string = DarwinDefaultDLLSSLName;
+    LastTriedDLLUtilName: string = DarwinDefaultDLLUtilName;
     {$ELSE}
      {$IFDEF OS2}
       {$IFDEF OS2GCC}
@@ -1874,10 +1883,107 @@ begin
 {$ENDIF}
 end;
 
+{$IFDEF DARWIN}
+function TryLoadOpenSSLPair(const UtilName, LibName: string): Boolean;
+var
+  LibHandle, UtilHandle: TLibHandle;
+begin
+  Result := False;
+  if FirstTriedDLLUtilName = '' then
+  begin
+    FirstTriedDLLUtilName := UtilName;
+    FirstTriedDLLSSLName := LibName;
+  end;
+  LastTriedDLLUtilName := UtilName;
+  LastTriedDLLSSLName := LibName;
+  LibHandle := 0;
+  UtilHandle := LoadLib(UtilName);
+  try
+    if UtilHandle = 0 then
+      Exit;
+    LibHandle := LoadLib(LibName);
+    if LibHandle = 0 then
+      Exit;
+    SSLUtilHandle := UtilHandle;
+    SSLLibHandle := LibHandle;
+    SSLUtilFile := UtilName;
+    SSLLibFile := LibName;
+    UtilHandle := 0;
+    LibHandle := 0;
+    Result := True;
+  finally
+    if LibHandle <> 0 then
+      FreeLibrary(LibHandle);
+    if UtilHandle <> 0 then
+      FreeLibrary(UtilHandle);
+  end;
+end;
+
+function TryLoadOpenSSLFrom(const LibDir, Version: string): Boolean;
+var
+  Path: string;
+begin
+  Path := IncludeTrailingPathDelimiter(LibDir);
+  Result := TryLoadOpenSSLPair(
+    Path + 'libcrypto.' + Version + '.dylib',
+    Path + 'libssl.' + Version + '.dylib');
+end;
+
+function LoadDarwinOpenSSL: Boolean;
+begin
+  FirstTriedDLLUtilName := '';
+  FirstTriedDLLSSLName := '';
+  if (DLLUtilName <> DarwinDefaultDLLUtilName) or
+    (DLLSSLName <> DarwinDefaultDLLSSLName) then
+  begin
+    Result := TryLoadOpenSSLPair(DLLUtilName, DLLSSLName);
+    Exit;
+  end;
+{$IFDEF CPUAARCH64}
+  Result := TryLoadOpenSSLFrom('/opt/homebrew/opt/openssl@3/lib', '3');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/usr/local/opt/openssl@3/lib', '3');
+{$ELSE}
+  Result := TryLoadOpenSSLFrom('/usr/local/opt/openssl@3/lib', '3');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/homebrew/opt/openssl@3/lib', '3');
+{$ENDIF}
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/local/libexec/openssl3/lib', '3');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/local/lib', '3');
+  if Result then
+    Exit;
+{$IFDEF CPUAARCH64}
+  Result := TryLoadOpenSSLFrom('/opt/homebrew/opt/openssl@1.1/lib', '1.1');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/usr/local/opt/openssl@1.1/lib', '1.1');
+{$ELSE}
+  Result := TryLoadOpenSSLFrom('/usr/local/opt/openssl@1.1/lib', '1.1');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/homebrew/opt/openssl@1.1/lib', '1.1');
+{$ENDIF}
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/local/libexec/openssl11/lib', '1.1');
+  if Result then
+    Exit;
+  Result := TryLoadOpenSSLFrom('/opt/local/lib', '1.1');
+end;
+{$ENDIF}
+
 function InitSSLInterface: Boolean;
+{$IFNDEF DARWIN}
 var
   s: string;
   x: integer;
+{$ENDIF}
 begin
   {pf}
   if SSLLoaded then
@@ -1894,6 +2000,9 @@ begin
       SSLLibHandle := 1;
       SSLUtilHandle := 1;
 {$ELSE}
+  {$IFDEF DARWIN}
+      LoadDarwinOpenSSL;
+  {$ELSE}
       SSLUtilHandle := LoadLib(DLLUtilName);
       SSLLibHandle := LoadLib(DLLSSLName);
   {$IFDEF MSWINDOWS}
@@ -1919,6 +2028,7 @@ begin
       if (SSLUtilHandle = 0) then
         SSLUtilHandle := LoadLib(DLLUtilName2);
     {$ENDIF}
+  {$ENDIF}
   {$ENDIF}
 {$ENDIF}
       if (SSLLibHandle <> 0) and (SSLUtilHandle <> 0) then
@@ -2045,6 +2155,7 @@ begin
         OPENSSLaddallalgorithms;
         RandScreen;
 {$ELSE}
+  {$IFNDEF DARWIN}
         SetLength(s, 1024);
         x := GetModuleFilename(SSLLibHandle,PChar(s),Length(s));
         SetLength(s, x);
@@ -2053,6 +2164,7 @@ begin
         x := GetModuleFilename(SSLUtilHandle,PChar(s),Length(s));
         SetLength(s, x);
         SSLUtilFile := s;
+  {$ENDIF}
         //init library
         if assigned(_SslLibraryInit) then
           _SslLibraryInit;
@@ -2128,7 +2240,7 @@ begin
 {$IFNDEF CIL}
       FreeLibrary(SSLUtilHandle);
 {$ENDIF}
-      SSLLibHandle := 0;
+      SSLUtilHandle := 0;
     end;
 
 {$IFNDEF CIL}


### PR DESCRIPTION
### **User description**
## Summary

- load `libcrypto` and `libssl` as a matching, versioned pair on macOS
- prefer OpenSSL 3 from Homebrew or MacPorts, with OpenSSL 1.1 retained only as
  a legacy fallback
- preserve explicit caller library overrides without restoring unsafe
  unversioned default lookups
- verify the production loader and override path on the macOS CI runner
- document the external OpenSSL and CPU architecture requirements

## Why

The previous Darwin defaults loaded unversioned libraries independently. On
newer macOS systems, an incompatible lookup can terminate the process, and
independent discovery can select mismatched OpenSSL libraries.

This change keeps both libraries from the same candidate location and records
the selected paths. It does not bundle OpenSSL or change certificate and
hostname verification; that work remains independent from #1526. Any
overlapping loader changes in #1509 or #1544 should be dropped when those
branches rebase.

The current disk image remains x86_64. HTTPS RPC therefore still requires an
x86_64 or universal OpenSSL installation when running on Apple Silicon through
Rosetta.

## Verification

- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/3.0`
- compiled the loader probe normally, with `-dDARWIN`, and with
  `-dDARWIN -dCPUAARCH64`
- `shellcheck setup/macosx/tests/verify_openssl_loader.sh`
- `sh -n setup/macosx/tests/verify_openssl_loader.sh`
- `git -c core.whitespace=cr-at-eol diff --check`
- completed a multi-reviewer local review loop; every successful final
  reviewer reported no actionable issues

The added macOS CI step performs the actual OpenSSL 3 runtime load, creates an
SSL context, exercises a non-standard override path, and verifies cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load `libcrypto` and `libssl` as a matching, versioned pair on macOS to prevent crashes and mismatches. Prefer OpenSSL 3 with arch-aware discovery, clearer first-attempt error messages, a CI loader probe, and updated macOS docs.

- **Bug Fixes**
  - Load macOS OpenSSL as a matched, versioned pair; set Darwin defaults to `libcrypto.3.dylib` and `libssl.3.dylib`; discover OpenSSL 3 via Homebrew/MacPorts with arch-aware paths (preferring `/opt/homebrew` on arm64 and checking `/usr/local/opt`), keeping OpenSSL 1.1 only as a legacy fallback.
  - Treat explicit Darwin overrides as authoritative; keep configured names separate from resolved paths so no silent fallback occurs; preserve discovery after cleanup/reinit.
  - Show the first attempted OpenSSL pair in the macOS error dialog; track both first and last attempts; fix cleanup to clear the correct handle; add a CI runtime loader probe that installs `openssl@3` and validates TLS init, override failures, reload, and cleanup.

- **Migration**
  - HTTPS on macOS requires OpenSSL 3: `brew install openssl@3` or `sudo port install openssl3`.
  - The disk image is x86_64. On Apple Silicon, use an x86_64 or universal OpenSSL (e.g., Intel Homebrew in `/usr/local` or MacPorts `+universal`); native arm64 Homebrew in `/opt/homebrew` cannot be loaded by the current image. Native arm64 builds prefer `/opt/homebrew` but can also use compatible Homebrew libraries under `/usr/local/opt`.
  - The Homebrew cask does not bundle OpenSSL and follows the same `openssl@3` and architecture requirements.

<sup>Written for commit 0ced67c9cadd8e61a5866f61aac1392ae82816b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS HTTPS RPC compatibility by reliably locating and loading OpenSSL 3 libraries.
  - Added support for common Homebrew and MacPorts OpenSSL installation paths.
  - Improved diagnostics when OpenSSL libraries cannot be loaded.

- **Documentation**
  - Clarified macOS OpenSSL requirements and installation steps.
  - Documented OpenSSL 1.1 compatibility, CPU architecture matching, and Rosetta 2 requirements for Apple Silicon Macs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Load matching, versioned OpenSSL pairs on macOS.

- Avoid unsafe unversioned macOS library lookups.

- Add CI runtime loader verification and probes.

- Document macOS OpenSSL architecture requirements.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Loader["macOS OpenSSL loader"]
  Candidates["Versioned Homebrew and MacPorts pairs"]
  Libraries["Matching libcrypto and libssl"]
  Probe["Runtime loader probe"]
  CI["macOS CI verification"]
  Loader -- "tries" --> Candidates
  Candidates -- "loads" --> Libraries
  Probe -- "validates" --> Loader
  CI -- "runs" --> Probe
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>rpc.pas</strong><dd><code>Report attempted macOS OpenSSL library paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-2ed877f1eb0cc61eeb41c8377461565d3043af70aaf9ac97b3a78679d020fa76">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>openssl_loader_probe.pas</strong><dd><code>Add OpenSSL loader runtime validation probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-89f76c2c7b379a176cf586bee880bef7d23e5ac1c065013b236bc2c7600f3854">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>verify_openssl_loader.sh</strong><dd><code>Build and execute macOS loader probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-8b6d933c80b3c255f525d50915abd92b38542ad362c2f1228360414d325b78f9">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ssl_openssl_lib.pas</strong><dd><code>Load matching versioned OpenSSL pairs on macOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-28cbf943502ab6c2035647708e6c69e1a2f6faa8c4b5d5b919d7e847e511547c">+115/-3</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Install OpenSSL and verify macOS loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document macOS OpenSSL installation architecture requirements</code></dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>readme.txt</strong><dd><code>Mirror macOS OpenSSL dependency installation guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1548/files#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

