### PR TITLE
Keep Windows Signatures Valid After Certificate Expiry

### DIFF
--- a/setup/win/make_setup.bat
+++ b/setup/win/make_setup.bat
@@ -24,7 +24,7 @@ make -C ../.. all
 if errorlevel 1 goto err
 
 if not (%CODECERT%) == () (
-  signtool.exe sign /d "Transmission Remote GUI" /du "https://github.com/transmission-remote-gui/transgui" /f "%CODECERT%" /v ..\..\transgui.exe
+  signtool.exe sign /d "Transmission Remote GUI" /du "https://github.com/transmission-remote-gui/transgui" /f "%CODECERT%" /fd sha256 /tr "http://timestamp.digicert.com" /td sha256 /v ..\..\transgui.exe
   if errorlevel 1 goto err
 )
 

--- a/setup/win/setup.iss
+++ b/setup/win/setup.iss
@@ -87,7 +87,7 @@ ShowLanguageDialog=yes
 
 #if GetEnv("CODECERT") != ""
 #define CODECERT GetEnv("CODECERT")
-SignTool=signtool sign /d "{#AppName} Setup" /du "{#AppURL}" /f "{#CODECERT}" /v $f
+SignTool=signtool sign /d "{#AppName} Setup" /du "{#AppURL}" /f "{#CODECERT}" /fd sha256 /tr "http://timestamp.digicert.com" /td sha256 /v $f
 #endif
 
 [Components]

--- a/setup/win_amd64/make_setup.bat
+++ b/setup/win_amd64/make_setup.bat
@@ -24,7 +24,7 @@ make -C ../.. all
 if errorlevel 1 goto err
 
 if not (%CODECERT%) == () (
-  signtool.exe sign /d "Transmission Remote GUI" /du "https://github.com/transmission-remote-gui/transgui" /f "%CODECERT%" /v ..\..\transgui.exe
+  signtool.exe sign /d "Transmission Remote GUI" /du "https://github.com/transmission-remote-gui/transgui" /f "%CODECERT%" /fd sha256 /tr "http://timestamp.digicert.com" /td sha256 /v ..\..\transgui.exe
   if errorlevel 1 goto err
 )
 

--- a/setup/win_amd64/setup.iss
+++ b/setup/win_amd64/setup.iss
@@ -89,7 +89,7 @@ ShowLanguageDialog=yes
 
 #if GetEnv("CODECERT") != ""
 #define CODECERT GetEnv("CODECERT")
-SignTool=signtool sign /d "{#AppName} Setup" /du "{#AppURL}" /f "{#CODECERT}" /v $f
+SignTool=signtool sign /d "{#AppName} Setup" /du "{#AppURL}" /f "{#CODECERT}" /fd sha256 /tr "http://timestamp.digicert.com" /td sha256 /v $f
 #endif
 
 [Components]


### PR DESCRIPTION
### Motivation

Windows signatures currently have no trusted timestamp, so they stop validating after the code-signing certificate expires.

### Description

- Restore timestamping for Windows binaries and installers using DigiCert's RFC 3161 endpoint.
- Use SHA-256 for both file and timestamp digests.
- Keep signing conditional on `CODECERT` and preserve existing failure handling.

### Verification

- Confirmed all four Windows signing commands use `/fd sha256`, `/tr`, and `/td sha256`.
- Confirmed the x86 and x64 signing paths remain synchronized and preserve CRLF line endings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows application and installer signing to use SHA-256 timestamping.
  * Improved the long-term validity and trust verification of signed Windows releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->