### PR TITLE
Make First-Launch Window Placement Predictable

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1529,6 +1529,7 @@ procedure TMainForm.FormCreate(Sender: TObject);
 var
   ws: TWindowState;
   i, j: integer;
+  M: TMonitor;
   R: TRect;
   SL: TStringList;
   MI, MI2: TMenuItem;
@@ -1666,7 +1667,13 @@ begin
   end;
 
   if Ini.ReadInteger('MainForm', 'State', -1) = -1 then begin
-    R:=Screen.MonitorFromRect(BoundsRect).WorkareaRect;
+    M:=Screen.PrimaryMonitor;
+    if (M = nil) and (Screen.MonitorCount > 0) then
+      M:=Screen.Monitors[0];
+    if M <> nil then
+      R:=M.WorkareaRect
+    else
+      R:=Rect(0, 0, Screen.Width, Screen.Height);
     if R.Right - R.Left < 300 then
       R:=Rect(0, 0, Screen.Width, Screen.Height);
     j:=R.Right - R.Left;
@@ -1676,7 +1683,7 @@ begin
       Width:=i;
     if Width > j then
       Width:=j;
-    Left:=(R.Right - R.Left - Width) div 2;
+    Left:=R.Left + (R.Right - R.Left - Width) div 2;
     j:=R.Bottom - R.Top;
     i:=j*3 div 4;
     j:=j*8 div 10;
@@ -1684,7 +1691,7 @@ begin
       Height:=i;
     if Height > j then
       Height:=j;
-    Top:=(R.Bottom - R.Top - Height) div 2;
+    Top:=R.Top + (R.Bottom - R.Top - Height) div 2;
   end
   else begin
     ws:=TWindowState(Ini.ReadInteger('MainForm', 'State', integer(WindowState)));


### PR DESCRIPTION
### Motivation

- Make first-launch window placement predictable instead of letting design-time form coordinates select an arbitrary display for a fresh profile.
- Center the window within the primary display's usable work area, including non-zero origins from multi-monitor layouts, taskbars, or docks.

### Description

- Select the primary monitor's work area for first-launch sizing and centering, with a first-enumerated-monitor fallback when no primary is identified and screen bounds as the final fallback.
- Include the work area's `Left` and `Top` offsets in the centering calculation so the resulting position uses absolute screen coordinates.
- Preserve existing size limits and saved-window-state restoration behavior.

### Testing

- `git diff --check`
- Positioning formula cases covering zero, positive, and negative work-area origins
- GitHub Actions builds: Linux (armv6l, armv7l, i686, x86_64) and macOS passed
- GitHub Actions zip tarball smoke test passed

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf773e560832781b27db2c6022d1d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first-launch window centering by accounting for the selected monitor's work-area origin. The window now centers correctly on any display, including multi-monitor setups with non-zero origins.

- **Bug Fixes**
  - Updated `Left` and `Top` to include `R.Left` / `R.Top` offsets in `main.pas`.
  - Kept existing width/height limits and other logic unchanged.

<sup>Written for commit 7e17c724366095eefea206d701cfd2239f781d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial window centering on monitors with non-zero screen offsets, ensuring the main window appears in the correct position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
