### PR TITLE
Guard Grid Hit Testing Against Invalid Cells

### DIFF
--- a/vargrid.pas
+++ b/vargrid.pas
@@ -763,7 +763,9 @@ begin
 {$endif LCLcarbon}
   CheckBoxClicked:=False;
   pt:=MouseToCell(Point(X,Y));
-  if ssLeft in Shift then begin
+  if (ssLeft in Shift) and
+     (pt.x >= 0) and (pt.x < ColCount) and
+     (pt.y >= 0) and (pt.y < RowCount) then begin
     SetupCell(pt.x, pt.y, [], ca);
     RR:=CellRect(pt.x, pt.y);
     Inc(RR.Left, ca.Indent);
@@ -796,14 +798,17 @@ begin
   end;
   if (ssRight in Shift) {$ifdef darwin} or (Shift*[ssLeft, ssCtrl] = [ssLeft, ssCtrl]) {$endif} then begin
     SetFocus;
-    if (pt.x >= FixedCols) and (pt.y >= FixedRows) then begin
+    if (pt.x >= FixedCols) and (pt.x < ColCount) and
+       (pt.y >= FixedRows) and (pt.y < RowCount) then begin
       if MultiSelect and (SelCount > 0) and not RowSelected[pt.y - FixedRows] then
         RemoveSelection;
       Row:=pt.y - FixedRows;
     end;
   end
   else
-    if MultiSelect and (ssLeft in Shift) and (pt.x >= FixedCols) and (pt.y >= FixedRows) then begin
+    if MultiSelect and (ssLeft in Shift) and
+       (pt.x >= FixedCols) and (pt.x < ColCount) and
+       (pt.y >= FixedRows) and (pt.y < RowCount) then begin
       if IsCtrl then begin
         if SelCount = 0 then
           RowSelected[Row]:=True;


### PR DESCRIPTION
### **User description**
### Motivation

Grid mouse handling used hit-test coordinates before fully validating their row and column bounds. Invalid or stale coordinates could reach cell attribute lookup, current-row updates, or multi-selection state and unexpectedly grow the grid data model or raise a range error.

### Description

- Validate both lower and upper cell-coordinate bounds before checkbox and tree-button hit testing.
- Apply the same upper-bound checks before right-click row changes and multi-select handling.
- Preserve focus handling and the inherited grid mouse behavior for clicks outside valid cells.

### Testing

- `lazbuild -B transgui.lpi --lazarusdir=<lazarus_dir>`
- `make LAZARUS_DIR=<lazarus_dir> all`
- `git diff --check origin/master...HEAD`


___

### **PR Type**
Bug fix


___

### **Description**
- Validate grid hit-test coordinates before cell access

- Prevent invalid clicks altering rows or selections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HitTest["Mouse hit-test coordinates"]
  Bounds["Validate grid row and column bounds"]
  Actions["Perform cell, row, or selection updates"]
  HitTest -- "validates" --> Bounds
  Bounds -- "permits valid coordinates" --> Actions
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vargrid.pas</strong><dd><code>Validate grid coordinates before mouse-driven updates</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vargrid.pas

<ul><li>Require in-range row and column coordinates before tree-button and <br>checkbox hit testing.<br> <li> Validate upper bounds before right-click current-row updates.<br> <li> Prevent multi-selection changes for invalid left-click hit-test <br>results.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1551/files#diff-d17225e70f5143a0f937451f414c996b51cc8a65f70225b4afaefb024dbfb64f">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

