### PR TITLE
Prevent Source Cleanup From Deleting Unrelated Files

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -706,7 +706,6 @@ type
     FFromNow: boolean;
     FWatchLocalFolder: string;
     FWatchDestinationFolder: string;
-    FWatchDownloading: boolean;
     FRow: integer;
     FCol: integer;
 {$ifdef windows}
@@ -746,7 +745,7 @@ type
     procedure LoadColumns(LV: TVarGrid; const AName: string; FullInfo: boolean = True);
     function GetTorrentError(t: TJSONObject; Status: integer): string;
     function SecondsToString(j: integer): string;
-    function DoAddTorrent(const FileName: Utf8String): boolean;
+    function DoAddTorrent(const FileName: Utf8String; IsWatchTorrent: boolean): boolean;
     procedure UpdateTray;
     procedure HideApp;
     procedure ShowApp;
@@ -1002,6 +1001,8 @@ const
 
   SpeedHistorySize = 20;
 
+  PendingWatchMarker = PtrUInt(1); // Never free or dereference this sentinel.
+
 const
   SizeNames: array[1..5] of string = (sByte, sKByte, sMByte, sGByte, sTByte);
 
@@ -1048,7 +1049,7 @@ begin
       begin
             if FindFirstUTF8(FWatchLocalFolder+'*.torrent',faAnyFile,sr)=0 then
               repeat
-                    FPendingTorrents.Add(FWatchLocalFolder+sr.Name);
+                    FPendingTorrents.AddObject(FWatchLocalFolder+sr.Name, TObject(PendingWatchMarker));
               until FindNextUTF8(sr)<>0;
             FindCloseUTF8(sr);
       end;
@@ -1634,6 +1635,7 @@ begin
   lvTrackers.AlternateColor:=FAlterColor;
   gStats.AlternateColor:=FAlterColor;
   FPendingTorrents:=TStringList.Create;
+  FPendingTorrents.OwnsObjects:=False; // Object slots hold the sentinel, not instances.
   FPendingClipboardTorrents:=TStringList.Create;
   FFilesCapt:=tabFiles.Caption;
   FPasswords:=TStringList.Create;
@@ -2406,14 +2408,14 @@ begin
     if ShowModal = mrOk then
       begin
           if isHash(edLink.Text) then edLink.Text := 'magnet:?xt=urn:btih:'+ edLink.Text;
-          DoAddTorrent(edLink.Text);
+          DoAddTorrent(edLink.Text, False);
       end;
   finally
     Free;
   end;
 end;
 
-function TMainForm.DoAddTorrent(const FileName: Utf8String): boolean;
+function TMainForm.DoAddTorrent(const FileName: Utf8String; IsWatchTorrent: boolean): boolean;
 var
   torrent: string;
   WaitForm: TBaseForm;
@@ -2736,7 +2738,7 @@ begin
 
         IniSec:='AddTorrent.' + FCurConn;
         FillDownloadDirs(cbDestFolder, 'LastDownloadDir');
-        if (FWatchDownloading) and (FWatchDestinationFolder <> '') then cbDestFolder.Text:=FWatchDestinationFolder;
+        if IsWatchTorrent and (FWatchDestinationFolder <> '') then cbDestFolder.Text:=FWatchDestinationFolder;
 
         req:=TJSONObject.Create;
         try
@@ -2845,7 +2847,7 @@ begin
         AppNormal;
 
         ok:=not Ini.ReadBool('Interface', 'ShowAddTorrentWindow', True);
-        if FWatchDownloading then ok:= true;
+        if IsWatchTorrent then ok:= true;
         if ok then
           btSelectAllClick(nil)
         else begin
@@ -2942,11 +2944,18 @@ begin
           SelectTorrent(id, 2000);
 
           id:=0;
-          if (Ini.ReadBool('Interface', 'DeleteTorrentFile', False) and not IsProtocolSupported(FileName)) or (FWatchDownloading) then
+          if not IsProtocolSupported(FileName) and
+              (IsWatchTorrent or
+               (Ini.ReadBool('Interface', 'DeleteTorrentFile', False) and
+                ((AnsiCompareText(ExtractFileExt(FileName), '.torrent') = 0) or
+                 (AnsiCompareText(ExtractFileName(FileName), '.torrent') = 0)))) then
             DeleteFileUTF8(FileName);
 
           Ini.WriteInteger(IniSec, 'PeerLimit', edPeerLimit.Value);
-          SaveDownloadDirs(cbDestFolder, 'LastDownloadDir');
+          if not IsWatchTorrent then
+            SaveDownloadDirs(cbDestFolder, 'LastDownloadDir')
+          else
+            Ini.UpdateFile;
           Result:=True;
           AppNormal;
         end;
@@ -4006,10 +4015,7 @@ begin
     exit;
   ReadLocalFolderWatch;
   if FPendingTorrents.Count > 0 then
-    begin
-      FWatchDownloading := true;
-      TickTimerTimer(nil);
-    end;
+    TickTimerTimer(nil);
 end;
 
 
@@ -8147,6 +8153,7 @@ var
   s: string;
   sl: TStringList;
   WasHidden: boolean;
+  IsWatchTorrent: boolean;
 begin
   h:=FileOpenUTF8(FIPCFileName, fmOpenRead or fmShareDenyWrite);
   if h <> System.THandle(-1) then begin
@@ -8179,7 +8186,8 @@ begin
 
   if not FLinksFromClipboard then
     FPendingClipboardTorrents.Clear
-  else if not FWatchDownloading and (FPendingClipboardTorrents.Count > 0) then begin
+  else if (FPendingClipboardTorrents.Count > 0) and
+    (FPendingTorrents.IndexOfObject(TObject(PendingWatchMarker)) < 0) then begin
     FPendingTorrents.AddStrings(FPendingClipboardTorrents);
     FPendingClipboardTorrents.Clear;
   end;
@@ -8196,15 +8204,15 @@ begin
         ShowApp;
       try
         while FPendingTorrents.Count > 0 do begin
+          IsWatchTorrent:=PtrUInt(FPendingTorrents.Objects[0]) = PendingWatchMarker;
           s:=FPendingTorrents[0];
           FPendingTorrents.Delete(0);
           if s <> '' then
-            DoAddTorrent(s);
+            DoAddTorrent(s, IsWatchTorrent);
         end;
       finally
         if WasHidden then
           HideTaskbarButton;
-          FWatchDownloading := false;
       end;
     end;
   finally


### PR DESCRIPTION
### **User description**
### Motivation

The pending add queue is shared by watch-folder scans, dialogs, IPC,
command-line arguments, and drag-and-drop. Its batch-wide watch flag could
misclassify unrelated queued entries as watched torrents, bypass normal
source cleanup safeguards, and delete an accepted local source file.

### Changes

- Track watch-folder provenance on each queued torrent instead of using a
  shared batch flag.
- Apply watch destination, prompt suppression, and post-add cleanup only to
  entries discovered by the watch scanner.
- Limit ordinary source cleanup to non-protocol `.torrent` files when
  `DeleteTorrentFile` is enabled.
- Preserve cleanup for every file accepted by the watch scanner, including a
  file named exactly `.torrent`.

### Result

Interleaved IPC, command-line, dialog, or drag-and-drop additions no longer
inherit watch-folder behavior. Watched torrents continue to be processed and
cleaned up as before.


___

### **PR Type**
Bug fix


___

### **Description**
- Isolate watch-folder provenance per queued torrent

- Prevent unrelated additions inheriting watch cleanup

- Restrict ordinary cleanup to local torrent files

- Preserve watch destinations without persisting them


___

### Diagram Walkthrough


```mermaid
flowchart LR
  watch["Watch-folder scan"] 
  queue["Pending torrent queue with watch marker"]
  add["Per-item add processing"]
  cleanup["Scoped destination and source cleanup"]
  watch -- "tags discovered files" --> queue
  queue -- "passes watch provenance" --> add
  add -- "applies only relevant behavior" --> cleanup
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Scope watch-folder behavior to individual queued torrents</code></dd></summary>
<hr>

main.pas

<ul><li>Tag watch-folder queue entries with a non-owned sentinel.<br> <li> Pass per-item watch status through the add workflow.<br> <li> Apply watch destination, prompt suppression, and cleanup only to <br>tagged entries.<br> <li> Limit regular source deletion to local <code>.torrent</code> files.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1553/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+24/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-folder torrent tracking and processing.
  * Watch-folder files are now reliably removed after processing.
  * Other torrent files are cleaned up only when enabled and when using the expected file type.
  * Pending clipboard links are deferred while watch-folder items remain active.
  * Improved destination selection and confirmation behavior for watch-folder additions.
  * Regular link additions continue to follow their normal destination, confirmation, and history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->