### PR TITLE
Keep Torrent Properties Aligned With Multi-Selection

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -4012,6 +4012,10 @@ begin
   gTorrentsClick(nil);
   id:=RpcObj.CurTorrentId;
   if id = 0 then exit;
+  TorrentIds:=GetSelectedTorrents;
+  if VarIsEmpty(TorrentIds) then exit;
+  id:=TorrentIds[VarArrayLowBound(TorrentIds, 1)];
+  if id = 0 then exit;
   AppBusy;
   trlist:=nil;
   with TTorrPropsForm.Create(Self) do
@@ -4019,7 +4023,6 @@ begin
     Page.ActivePageIndex:=PageNo;
     gTorrents.Tag:=1;
     gTorrents.EnsureSelectionVisible;
-    TorrentIds:=GetSelectedTorrents;
     args:=RpcObj.RequestInfo(id, ['downloadLimit', 'downloadLimitMode', 'downloadLimited', 'uploadLimit', 'uploadLimitMode', 'uploadLimited',
                                   'name', 'maxConnectedPeers', 'seedRatioMode', 'seedRatioLimit', 'seedIdleLimit', 'seedIdleMode', 'trackers']);
     if args = nil then begin


### PR DESCRIPTION
### **User description**
### Motivation

- Prevent Torrent Properties from displaying a focused torrent while applying confirmed changes to a different multi-selection target set.
- Keep the dialog's initial values aligned with the torrents that will be updated.

### Description

- Capture the selected torrent IDs before entering the busy state.
- Load initial properties from the first valid ID in that snapshot while retaining the complete snapshot for the later `torrent-set` request.
- Exit safely when no torrent IDs are available or the representative ID is invalid, rather than indexing an unassigned Variant or issuing an unscoped request.

### Testing

- `git diff --check`
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/`
- `make -j2 LAZARUS_DIR=/usr/lib/lazarus/default/ all`
- Focused review of empty, zero-ID, and valid Variant paths
- GUI interaction was not exercised

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf651e74c832780c5ef380094f81f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent property loading by ensuring the first selected torrent is used when initializing the details view.
  * Prevented the properties window from opening when no torrent is selected or when an invalid selection is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Load properties from the first selected torrent

- Align dialog data with multi-torrent update targets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  selected["Selected torrent IDs"]
  first["First selected torrent"]
  dialog["Properties dialog data"]
  update["Multi-torrent property update"]
  selected -- "select first ID" --> first
  first -- "loads initial values" --> dialog
  selected -- "remains update target list" --> update
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Align properties dialog with selected torrents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Select the first ID from <code>GetSelectedTorrents</code>.<br> <li> Request initial properties for that selected torrent.<br> <li> Keep displayed values aligned with selected update targets.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1554/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+1/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>


___


___

### **PR Type**
Bug fix


___

### **Description**
- Snapshot selected torrents before opening properties.

- Load dialog values from the selected update target.

- Skip empty or invalid selections safely.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  selection["Selected torrent IDs"]
  representative["First selected torrent"]
  dialog["Properties dialog"]
  update["torrent-set targets"]
  selection -- "chooses first ID" --> representative
  representative -- "loads initial values" --> dialog
  selection -- "retains all IDs" --> update
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Align properties dialog with selected torrent targets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Capture <code>GetSelectedTorrents</code> before entering the busy state.<br> <li> Use the first selected ID to load initial properties.<br> <li> Exit when the selection is empty or invalid.<br> <li> Preserve the full selection for subsequent multi-torrent updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1554/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

