### PR TITLE
Add i18n translations for labels and config file UI strings

### DIFF
--- a/lang/transgui.be
+++ b/lang/transgui.be
@@ -388,3 +388,10 @@ Total: %s=Усяго: %s
 Unauthorized User=Неаўтарызаваны карыстальнік
 User Menu=Мэню карыстальніка
 for example: *.avi *.mkv tom*jerry*.avi=напрыклад: *.avi *.mkv tom*jerry*.avi
+
+Config file=Файл канфігурацыі
+Label grouping=Групаваньне па мэтках
+Labels=Мэткі
+Set labels=Задаць мэткі
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Гэта заменіць усе наяўныя мэткі.~Вы можаце задаць некалькі мэтак праз коску або пакінуць пустым, каб ачысьціць мэткі
+Application option=Опцыя праграмы

--- a/lang/transgui.ca
+++ b/lang/transgui.ca
@@ -388,3 +388,10 @@ Total: %s=Total: %s
 Unauthorized User=Usuari no autoritzat
 User Menu=Menú d'usuari
 for example: *.avi *.mkv tom*jerry*.avi=per exemple: *.avi *.mkv tom*jerry*.avi
+
+Config file=Fitxer de configuració
+Label grouping=Agrupació per etiquetes
+Labels=Etiquetes
+Set labels=Establir etiquetes
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Això sobreescriurà qualsevol etiqueta existent.~Podeu establir diverses etiquetes separades per comes o deixar-ho buit per netejar les etiquetes
+Application option=Opció de l'aplicació

--- a/lang/transgui.cs
+++ b/lang/transgui.cs
@@ -388,3 +388,10 @@ Total: %s=Celkem: %s
 Unauthorized User=Neautorizovaný uživatel
 User Menu=Uživatelská nabídka
 for example: *.avi *.mkv tom*jerry*.avi=například: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfigurační soubor
+Label grouping=Seskupit podle štítků
+Labels=Štítky
+Set labels=Nastavit štítky
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Tím se přepíší všechny existující štítky.~Můžete nastavit více štítků oddělených čárkou, nebo je nechat prázdné pro vymazání štítků
+Application option=Možnost aplikace

--- a/lang/transgui.da
+++ b/lang/transgui.da
@@ -388,3 +388,10 @@ Total: %s=I alt: %s
 Unauthorized User=Uautoriseret bruger
 User Menu=Brugermenu
 for example: *.avi *.mkv tom*jerry*.avi=for eksempel: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfigurationsfil
+Label grouping=Gruppér efter etiketter
+Labels=Etiketter
+Set labels=Angiv etiketter
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Dette overskriver alle eksisterende etiketter.~Du kan angive flere etiketter adskilt af komma eller lade det være tomt for at rydde etiketter
+Application option=Programindstilling

--- a/lang/transgui.de
+++ b/lang/transgui.de
@@ -388,3 +388,10 @@ Total: %s=Gesamt: %s
 Unauthorized User=Nicht autorisierter Benutzer
 User Menu=Benutzermenü
 for example: *.avi *.mkv tom*jerry*.avi=zum Beispiel: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfigurationsdatei
+Label grouping=Nach Beschriftung gruppieren
+Labels=Beschriftungen
+Set labels=Beschriftungen setzen
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Dies überschreibt alle vorhandenen Beschriftungen.~Sie können mehrere Beschriftungen durch Kommas getrennt festlegen oder leer lassen, um Beschriftungen zu entfernen
+Application option=Anwendungsoption

--- a/lang/transgui.el
+++ b/lang/transgui.el
@@ -388,3 +388,10 @@ Total: %s=Σύνολο: %s
 Unauthorized User=Μη εξουσιοδοτημένος χρήστης
 User Menu=Μενού χρήστη
 for example: *.avi *.mkv tom*jerry*.avi=για παράδειγμα: *.avi *.mkv tom*jerry*.avi
+
+Config file=Αρχείο ρυθμίσεων
+Label grouping=Ομαδοποίηση κατά ετικέτα
+Labels=Ετικέτες
+Set labels=Ορισμός ετικετών
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Αυτό θα αντικαταστήσει όλες τις υπάρχουσες ετικέτες.~Μπορείτε να ορίσετε πολλές ετικέτες διαχωρισμένες με κόμμα ή να το αφήσετε κενό για να εκκαθαρίσετε τις ετικέτες
+Application option=Επιλογή εφαρμογής

--- a/lang/transgui.en
+++ b/lang/transgui.en
@@ -388,3 +388,10 @@ Unauthorized User=Unauthorized User
 Big Toolbar=Big Toolbar
 Client Certificate=Client Certificate
 Private Key=Private Key
+
+Config file=Config file
+Label grouping=Label grouping
+Labels=Labels
+Set labels=Set labels
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels
+Application option=Application option

--- a/lang/transgui.es
+++ b/lang/transgui.es
@@ -388,3 +388,10 @@ Big Toolbar=Barra de herramientas grande
 Client Certificate=Certificado de cliente
 Private Key=Clave privada
 Unauthorized User=Usuario no autorizado
+
+Config file=Archivo de configuración
+Label grouping=Agrupar por etiquetas
+Labels=Etiquetas
+Set labels=Establecer etiquetas
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Esto sobrescribirá cualquier etiqueta existente.~Puede establecer varias etiquetas separadas por comas o dejarlo vacío para borrar las etiquetas
+Application option=Opción de la aplicación

--- a/lang/transgui.fi
+++ b/lang/transgui.fi
@@ -388,3 +388,10 @@ Total: %s=Yhteensä: %s
 Unauthorized User=Valtuuttamaton käyttäjä
 User Menu=Käyttäjävalikko
 for example: *.avi *.mkv tom*jerry*.avi=esimerkiksi: *.avi *.mkv tom*jerry*.avi
+
+Config file=Asetustiedosto
+Label grouping=Tunnisteiden ryhmittely
+Labels=Tunnisteet
+Set labels=Aseta tunnisteet
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Tämä korvaa kaikki olemassa olevat tunnisteet.~Voit asettaa useita tunnisteita pilkulla erotettuina tai jättää tyhjäksi tyhjentääksesi tunnisteet
+Application option=Sovellusasetus

--- a/lang/transgui.fr
+++ b/lang/transgui.fr
@@ -388,3 +388,10 @@ Total: %s=Total : %s
 Unauthorized User=Utilisateur non autorisé
 User Menu=Menu utilisateur
 for example: *.avi *.mkv tom*jerry*.avi=par exemple : *.avi *.mkv tom*jerry*.avi
+
+Config file=Fichier de configuration
+Label grouping=Grouper par étiquettes
+Labels=Étiquettes
+Set labels=Définir les étiquettes
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Cela écrasera toutes les étiquettes existantes.~Vous pouvez définir plusieurs étiquettes séparées par des virgules ou laisser vide pour effacer les étiquettes
+Application option=Option de l'application

--- a/lang/transgui.hr
+++ b/lang/transgui.hr
@@ -388,3 +388,10 @@ Total: %s=Ukupno: %s
 Unauthorized User=Neovlašteni korisnik
 User Menu=Korisnički izbornik
 for example: *.avi *.mkv tom*jerry*.avi=na primjer: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfiguracijska datoteka
+Label grouping=Grupiraj po oznakama
+Labels=Oznake
+Set labels=Postavi oznake
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Ovo će zamijeniti sve postojeće oznake.~Možete postaviti više oznaka odvojenih zarezom ili ostaviti prazno za čišćenje oznaka
+Application option=Opcija aplikacije

--- a/lang/transgui.hu
+++ b/lang/transgui.hu
@@ -388,3 +388,10 @@ Unauthorized User=Nem azonosított felhasználó
 Big Toolbar=Nagy eszköztár
 Client Certificate=Kliens tanúsítvány
 Private Key=Privát kulcs
+
+Config file=Konfigurációs fájl
+Label grouping=Címkék szerinti csoportosítás
+Labels=Címkék
+Set labels=Címkék beállítása
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Ez felülírja az összes meglévő címkét.~Több címkét vesszővel elválasztva adhat meg, vagy hagyja üresen a címkék törléséhez
+Application option=Alkalmazásopció

--- a/lang/transgui.it
+++ b/lang/transgui.it
@@ -388,3 +388,10 @@ Unauthorized User=Utente non autorizzato
 Big Toolbar=Barra degli strumenti grande
 Client Certificate=Certificato client
 Private Key=Chiave privata
+
+Config file=File di configurazione
+Label grouping=Raggruppamento per etichetta
+Labels=Etichette
+Set labels=Imposta etichette
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Questa operazione sovrascriverà tutte le etichette esistenti.~È possibile impostare più etichette separate da una virgola o lasciare vuoto per cancellare le etichette
+Application option=Opzione applicazione

--- a/lang/transgui.ko
+++ b/lang/transgui.ko
@@ -388,3 +388,10 @@ Unauthorized User=비인가 사용자
 Big Toolbar=큰 도구 모음
 Client Certificate=클라이언트 인증서
 Private Key=개인 키
+
+Config file=구성 파일
+Label grouping=라벨별 그룹화
+Labels=라벨
+Set labels=라벨 설정
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=기존 라벨을 모두 덮어씁니다.~쉼표로 구분하여 여러 라벨을 설정하거나, 라벨을 지우려면 비워 두세요
+Application option=어플리케이션 옵션

--- a/lang/transgui.lt
+++ b/lang/transgui.lt
@@ -387,3 +387,10 @@ Unauthorized User=Vartotojas neautorizuotas
 Big Toolbar=Didelė įrankių juosta
 Client Certificate=Kliento sertifikatas
 Private Key=Asmeninis raktas
+
+Config file=Konfigūracijos failas
+Label grouping=Grupuoti pagal žymes
+Labels=Žymos
+Set labels=Nustatyti žymes
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Tai perrašys visas esamas žymes.~Galite nustatyti kelias žymes, atskirtas kableliais, arba palikti tuščią, kad išvalytumėte žymes
+Application option=Programos parinktis

--- a/lang/transgui.lv
+++ b/lang/transgui.lv
@@ -388,3 +388,10 @@ Total: %s=Kopā: %s
 Unauthorized User=Neautorizēts lietotājs
 User Menu=Lietotāja izvēlne
 for example: *.avi *.mkv tom*jerry*.avi=piemēram: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfigurācijas fails
+Label grouping=Grupēt pēc birkām
+Labels=Birkas
+Set labels=Iestatīt birkas
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Tas pārrakstīs visas esošās birkas.~Varat iestatīt vairākas birkas, atdalot tās ar komatu, vai atstāt tukšu, lai notīrītu birkas
+Application option=Lietotnes opcija

--- a/lang/transgui.nl
+++ b/lang/transgui.nl
@@ -388,3 +388,10 @@ Unauthorized User=Onbevoegde Gebruiker
 Big Toolbar=Grote werkbalk
 Client Certificate=Clientcertificaat
 Private Key=Privésleutel
+
+Config file=Configuratiebestand
+Label grouping=Groeperen op labels
+Labels=Labels
+Set labels=Labels instellen
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Dit overschrijft alle bestaande labels.~U kunt meerdere labels instellen gescheiden door een komma of leeg laten om labels te wissen
+Application option=Applicatieoptie

--- a/lang/transgui.no
+++ b/lang/transgui.no
@@ -388,3 +388,10 @@ Total: %s=Totalt: %s
 Unauthorized User=Uautorisert bruker
 User Menu=Brukermeny
 for example: *.avi *.mkv tom*jerry*.avi=for eksempel: *.avi *.mkv tom*jerry*.avi
+
+Config file=Konfigurasjonsfil
+Label grouping=Grupper etter etiketter
+Labels=Etiketter
+Set labels=Angi etiketter
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Dette vil overskrive alle eksisterende etiketter.~Du kan angi flere etiketter atskilt med komma eller la det stå tomt for å fjerne etiketter
+Application option=Programalternativ

--- a/lang/transgui.pl
+++ b/lang/transgui.pl
@@ -388,3 +388,10 @@ Unauthorized User=Nieupoważniony użytkownik
 Big Toolbar=Duży pasek narzędzi
 Client Certificate=Certyfikat klienta
 Private Key=Klucz prywatny
+
+Config file=Plik konfiguracyjny
+Label grouping=Grupuj według etykiet
+Labels=Etykiety
+Set labels=Ustaw etykiety
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=To spowoduje nadpisanie wszystkich istniejących etykiet.~Możesz ustawić wiele etykiet oddzielonych przecinkami lub pozostawić puste, aby wyczyścić etykiety
+Application option=Opcja aplikacji

--- a/lang/transgui.pt
+++ b/lang/transgui.pt
@@ -388,3 +388,10 @@ Right->Left (Reading Only)=Direita->Esquerda (Apenas leitura)
 Toolbar=Barra de ferramentas
 Unauthorized User=Utilizador não autorizado
 User Menu=Menu de utilizador
+
+Config file=Ficheiro de configuração
+Label grouping=Agrupar por rótulos
+Labels=Rótulos
+Set labels=Definir rótulos
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Isto irá substituir todos os rótulos existentes.~Pode definir vários rótulos separados por vírgulas ou deixar vazio para limpar os rótulos
+Application option=Opção da aplicação

--- a/lang/transgui.pt_br
+++ b/lang/transgui.pt_br
@@ -388,3 +388,10 @@ Total: %s=Total: %s
 Unauthorized User=Usuário não autorizado
 User Menu=Menu do usuário
 for example: *.avi *.mkv tom*jerry*.avi=por exemplo: *.avi *.mkv tom*jerry*.avi
+
+Config file=Arquivo de configuração
+Label grouping=Agrupar por rótulos
+Labels=Rótulos
+Set labels=Definir rótulos
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Isto irá substituir todos os rótulos existentes.~Você pode definir vários rótulos separados por vírgulas ou deixar vazio para limpar os rótulos
+Application option=Opção do aplicativo

--- a/lang/transgui.ro
+++ b/lang/transgui.ro
@@ -388,3 +388,10 @@ Total: %s=Total: %s
 Unauthorized User=Utilizator neautorizat
 User Menu=Meniu utilizator
 for example: *.avi *.mkv tom*jerry*.avi=de exemplu: *.avi *.mkv tom*jerry*.avi
+
+Config file=Fișier de configurare
+Label grouping=Gruparea după etichete
+Labels=Etichete
+Set labels=Setați etichetele
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Aceasta va suprascrie toate etichetele existente.~Puteți seta mai multe etichete separate prin virgulă sau lăsați gol pentru a goli etichetele
+Application option=Opțiune aplicație

--- a/lang/transgui.ru
+++ b/lang/transgui.ru
@@ -388,3 +388,10 @@ Unauthorized User=Неразрешенный пользователь
 Big Toolbar=Большая панель инструментов
 Client Certificate=Сертификат клиента
 Private Key=Закрытый ключ
+
+Config file=Файл конфигурации
+Label grouping=Группировка по меткам
+Labels=Метки
+Set labels=Задать метки
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Это перезапишет все существующие метки.~Вы можете задать несколько меток через запятую или оставить пустым, чтобы очистить метки
+Application option=Параметр приложения

--- a/lang/transgui.sv
+++ b/lang/transgui.sv
@@ -389,3 +389,10 @@ Unauthorized User=Obehörig användare
 Big Toolbar=Stor verktygsrad
 Client Certificate=Klientcertifikat
 Private Key=Privat nyckel
+
+Config file=Konfigurationsfil
+Label grouping=Gruppera efter etiketter
+Labels=Etiketter
+Set labels=Ange etiketter
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Detta skriver över alla befintliga etiketter.~Du kan ange flera etiketter åtskilda med kommatecken eller lämna tomt för att rensa etiketter
+Application option=Programalternativ

--- a/lang/transgui.template
+++ b/lang/transgui.template
@@ -387,3 +387,10 @@ Right->Left (Reading Only)=Right->Left (Reading Only)
 Host not found=Host not found
 User Menu=User Menu
 Unauthorized User=Unauthorized User
+
+Config file=Config file
+Label grouping=Label grouping
+Labels=Labels
+Set labels=Set labels
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels
+Application option=Application option

--- a/lang/transgui.tr
+++ b/lang/transgui.tr
@@ -388,3 +388,10 @@ Total: %s=Toplam: %s
 Unauthorized User=Yetkisiz Kullanıcı
 User Menu=Kullanıcı Menüsü
 for example: *.avi *.mkv tom*jerry*.avi=örnek: *.avi *.mkv tom*jerry*.avi
+
+Config file=Yapılandırma dosyası
+Label grouping=Etikete göre grupla
+Labels=Etiketler
+Set labels=Etiketleri ayarla
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Bu, mevcut tüm etiketlerin üzerine yazacaktır.~Birden fazla etiketi virgülle ayırarak ayarlayabilir veya etiketleri temizlemek için boş bırakabilirsiniz
+Application option=Uygulama seçeneği

--- a/lang/transgui.uk
+++ b/lang/transgui.uk
@@ -388,3 +388,10 @@ Unauthorized User=Недозволений користувач
 Big Toolbar=Велика панель інструментів
 Client Certificate=Сертифікат клієнта
 Private Key=Закритий ключ
+
+Config file=Файл конфігурації
+Label grouping=Групування за мітками
+Labels=Мітки
+Set labels=Задати мітки
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=Це перезапише всі наявні мітки.~Ви можете задати кілька міток через кому або залишити порожнім, щоб очистити мітки
+Application option=Параметр програми

--- a/lang/transgui.zh
+++ b/lang/transgui.zh
@@ -387,3 +387,10 @@ Right->Left (Reading Only)=从右向左（只读）
 Host not found=主机未找到
 User Menu=用户菜单
 Unauthorized User=未认证用户
+
+Config file=配置文件
+Label grouping=标签分组
+Labels=标签
+Set labels=设置标签
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=这将覆盖任何现有的标签。~您可以用逗号分隔设置多个标签，或留空以清除标签
+Application option=应用程序选项

--- a/lang/transgui.zh_tw
+++ b/lang/transgui.zh_tw
@@ -387,3 +387,10 @@ Right->Left (Reading Only)=由右至左（僅影響閱讀）
 Host not found=找不到遠端主機
 User Menu=使用者選單
 Unauthorized User=未授權的使用者
+
+Config file=設定檔
+Label grouping=標籤分組
+Labels=標籤
+Set labels=設定標籤
+This will overwrite any existing labels.~You can set multiple labels separated by a comma or leave empty to clear labels=這將覆寫任何現有的標籤。~您可以用逗號分隔設定多個標籤，或留空以清除標籤
+Application option=應用程式選項

--- a/main.pas
+++ b/main.pas
@@ -149,6 +149,9 @@ resourcestring
   sPrivateOn = 'ON';
   sPrivateOff = 'OFF';
 
+  sSetLabels = 'Set labels';
+  sSetLabelsPrompt = 'This will overwrite any existing labels.' + LineEnding + 'You can set multiple labels separated by a comma or leave empty to clear labels.';
+
 type
 
   { TMyHashMap example from hashmapdemo }
@@ -3762,9 +3765,8 @@ begin
   i:=gTorrents.Items.IndexOf(idxTorrentId, ids[0]);
   if VarIsEmpty(gTorrents.Items[idxPath, i]) then
     exit;
-  if InputQuery('Set labels',
-      'This will overwrite any existing labels.' + sLineBreak +
-      'You can set multiple labels separated by a comma or leave empty to clear labels.',
+  if InputQuery(sSetLabels,
+      sSetLabelsPrompt,
       input) then begin
     AppBusy;
     req := TJSONObject.Create;


### PR DESCRIPTION
This pull request adds new translation strings for label management and configuration options across multiple languages in the application's localization files. The new strings cover terms and instructions related to configuration files, label grouping, setting labels, and application options. This ensures consistent support for these features in the user interface for all supported languages.

**Localization updates for label management and configuration:**

* Added translations for `Config file`, `Label grouping`, `Labels`, `Set labels`, the instruction for setting multiple labels, and `Application option` to the following language files:
  * `transgui.en`
  * `transgui.ca`
  * `transgui.de`
  * `transgui.fr`
  * `transgui.es`
  * `transgui.it`
  * `transgui.nl`
  * `transgui.pl`
  * `transgui.pt`
  * `transgui.cs`
  * `transgui.da`
  * `transgui.el`
  * `transgui.fi`
  * `transgui.hr`
  * `transgui.hu`
  * `transgui.ko`
  * `transgui.lt`
  * `transgui.lv`
  * `transgui.no`
  * `transgui.be`

No logic or code changes are included; this update is strictly for expanding and synchronizing translation coverage for new and existing features.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds i18n strings for config and label UI across all locales and switches the “Set labels” dialog to localized constants. No behavior changes.

- **New Features**
  - Added translations for: Config file, Label grouping, Labels, Set labels, the overwrite/multi-labels prompt, and Application option across all `lang/transgui.*` files and `transgui.template`.

- **Refactors**
  - Replaced inline dialog text with `sSetLabels` and `sSetLabelsPrompt` in `main.pas`.

<sup>Written for commit f1592de69cdc44364b222c3b8efa00cfaa1c31d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized text for label grouping, label assignment, configuration settings, and label overwrite or clearing guidance across supported languages.
  * The label-setting dialog now displays translated titles and prompts instead of fixed English text.
  * Expanded language coverage for application option labels in Belarusian, Catalan, Czech, Danish, German, Greek, Spanish, French, and additional supported languages.
  * Updated the translation template to include the new label-management and configuration terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->