### PR TITLE
Make macOS dependency downloads resilient to SourceForge failures

### DIFF
--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -6,20 +6,108 @@ set -e
 lazarus_ver="2.0.8"
 fpc="fpc-3.0.4-macos-x86_64-laz-2"
 lazarus="LazarusIDE-2.0.8-macos-x86_64"
+sourceforge_base="https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}"
+download_attempts=3
+download_timeout="${download_timeout:-600}"
+download_backoff=5
 
 if [ -n "${sourceforge_mirror-}" ]; then
   mirror_string="&use_mirror=${sourceforge_mirror}"
 fi
 
+cleanup_downloads() {
+  rm -f "fpc.pkg.part" "lazarus.pkg.part"
+}
+
+trap cleanup_downloads EXIT
+
+download_url() {
+  download_url_value="$1"
+  download_destination="$2"
+  partial="${download_destination}.part"
+  attempt=1
+
+  while [ "$attempt" -le "$download_attempts" ]; do
+    rm -f "$partial"
+    if curl --fail --location \
+      --connect-timeout 30 --max-time "$download_timeout" \
+      --output "$partial" "$download_url_value"; then
+      mv "$partial" "$download_destination" || return 1
+      return 0
+    fi
+
+    if [ "$attempt" -lt "$download_attempts" ]; then
+      next_attempt=$((attempt + 1))
+      echo "Download failed; retrying ($next_attempt/$download_attempts)" >&2
+      sleep $((attempt * download_backoff))
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "Download failed after $download_attempts attempts: $download_url_value" >&2
+  rm -f "$partial"
+  return 1
+}
+
+download_package() {
+  package="$1"
+  destination="$2"
+  package_url="${sourceforge_base}/${package}?r=&ts=$(date +%s)"
+
+  rm -f "${destination}.part"
+
+  if [ -n "${mirror_string-}" ]; then
+    if download_url "${package_url}${mirror_string}" "$destination"; then
+      return 0
+    fi
+
+    echo "Preferred SourceForge mirror failed; retrying automatic selection" >&2
+    rm -f "${destination}.part"
+  fi
+
+  download_url "$package_url" "$destination"
+}
+
+ppcx64_target="/usr/local/lib/fpc/3.0.4/ppcx64"
+ppcx64_link="/usr/local/bin/ppcx64"
+
+validate_ppcx64_link() {
+  if [ -L "$ppcx64_link" ]; then
+    ppcx64_link_target="$(readlink "$ppcx64_link")"
+    case "$ppcx64_link_target" in
+      /*) ppcx64_target_dir="$(dirname "$ppcx64_link_target")" ;;
+      *) ppcx64_target_dir="$(dirname "$ppcx64_link")/$(dirname "$ppcx64_link_target")" ;;
+    esac
+    if ppcx64_target_dir="$(cd -P "$ppcx64_target_dir" 2> /dev/null && pwd)" &&
+      [ "$ppcx64_target_dir/$(basename "$ppcx64_link_target")" = "$ppcx64_target" ]; then
+      return 0
+    fi
+    echo "$ppcx64_link exists and does not resolve to $ppcx64_target" >&2
+    return 1
+  fi
+
+  if [ -e "$ppcx64_link" ]; then
+    echo "$ppcx64_link exists and is not a symlink" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 if [ ! -x "$(command -v fpc 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$fpc.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "fpc.pkg"
-  sudo ln -s /usr/local/lib/fpc/3.0.4/ppcx64 /usr/local/bin/ppcx64
+  validate_ppcx64_link
+  download_package "$fpc.pkg" "fpc.pkg"
   sudo installer -pkg "fpc.pkg" -target /
+  if [ ! -e "$ppcx64_link" ] && [ ! -L "$ppcx64_link" ]; then
+    sudo ln -s "$ppcx64_target" "$ppcx64_link"
+  else
+    validate_ppcx64_link
+  fi
   rm "fpc.pkg"
 fi
 
 if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$lazarus.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "lazarus.pkg"
+  download_package "$lazarus.pkg" "lazarus.pkg"
   sudo installer -pkg "lazarus.pkg" -target /
   rm "lazarus.pkg"
 fi


### PR DESCRIPTION
## Summary

Improve the macOS dependency download path for transient SourceForge failures.

- Retry package transfers with bounded backoff.
- Fall back from the preferred mirror to SourceForge automatic selection.
- Keep incomplete downloads in `.part` files and restart failed attempts cleanly.
- Create the FPC compiler symlink after successful installation.

## Validation

- `sh -n setup/macosx/install_deps.sh`
- `shellcheck -s sh setup/macosx/install_deps.sh`
- `shfmt -sr -i 2 -d setup/macosx/install_deps.sh`
- ShellCheck for all shell scripts
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes macOS dependency downloads resilient to SourceForge hiccups. Adds retries with backoff, mirror fallback, atomic `.part` downloads with cleanup, and stricter `ppcx64` symlink validation after install.

- **Bug Fixes**
  - Retries each download with backoff and falls back from preferred mirror to automatic; uses `curl` with a 30s connect timeout and a configurable `download_timeout` (default 600s).
  - Writes to `.part` files, cleans them on exit, and restarts failed attempts cleanly.
  - Validates `/usr/local/bin/ppcx64`; creates it only if missing and rejects paths that don’t resolve to `/usr/local/lib/fpc/3.0.4/ppcx64`.

<sup>Written for commit 331733eb4a4d81860b473aa066e5e0a775fc9e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS dependency downloads with retries, timeouts, automatic mirror fallback, and cleanup of incomplete files.
  * Made compiler installation more reliable by completing installation before creating or validating its command-line link.
  * Prevented unnecessary replacement of existing compiler links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->