### PR TITLE
Stabilize macOS Lazarus build state

### DIFF
--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -4,7 +4,6 @@ set -ex
 
 prog_ver="$(cat ../../VERSION.txt)"
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD ../..)"
-lazarus_ver="$(lazbuild -v)"
 fpc_ver="$(fpc -i V | head -n 1)"
 exename=../../transgui
 appname="Transmission Remote GUI"
@@ -12,11 +11,18 @@ dmg_dist_file="../../Release/transgui-$prog_ver.dmg"
 dmg_temp_file="$dmg_dist_file.tmp.dmg"
 dmgfolder=./Release
 appfolder="$dmgfolder/$appname.app"
-lazdir="${1:-/Library/Lazarus/}"
+lazarus_dir="${1:-/Library/Lazarus/}"
+lazbuild_bin="$lazarus_dir/lazbuild"
+if [ ! -x "$lazbuild_bin" ]; then
+  echo "Unable to find lazbuild at $lazbuild_bin." >&2
+  exit 1
+fi
+lazarus_ver="$("$lazbuild_bin" -v)"
 mount_device=""
 remove_dmg_temp=0
 remove_dmgfolder=0
 remove_tmp_dmg=0
+lazarus_pcp=""
 
 detach_disk_image() {
   detach_device=$1
@@ -65,6 +71,9 @@ cleanup() {
   if [ -e ../../about.lfm.bak ]; then
     mv ../../about.lfm.bak ../../about.lfm || cleanup_status=$?
   fi
+  if [ -n "$lazarus_pcp" ]; then
+    rm -rf "$lazarus_pcp" || :
+  fi
 
   if [ "$status" -eq 0 ]; then
     status=$cleanup_status
@@ -76,8 +85,8 @@ if [ -z "${CI-}" ]; then
   ./install_deps.sh
 fi
 
-if [ ! "$lazdir" = "" ]; then
-  lazdir=LAZARUS_DIR="$lazdir"
+if [ ! "$lazarus_dir" = "" ]; then
+  lazdir=LAZARUS_DIR="$lazarus_dir"
 fi
 
 if [ -e ../../about.lfm.bak ]; then
@@ -96,10 +105,23 @@ fi
 trap cleanup 0
 trap 'exit 1' HUP INT TERM
 
+lazarus_pcp="$(mktemp -d "${TMPDIR:-/tmp}/transgui-lazarus-pcp.XXXXXX")" || exit 1
+
+cleanup_lazbuild_state() {
+  rm -rf ../../units ../../lib
+  mkdir -p ../../units ../../lib "$lazarus_pcp"
+}
+
+run_lazbuild() {
+  cleanup_lazbuild_state
+  "$lazbuild_bin" -B ../../trcomp.lpk --lazarusdir="$lazarus_dir" --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
+  "$lazbuild_bin" -B ../../transgui.lpi --lazarusdir="$lazarus_dir" --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
+}
+
 mkdir -p ../../Release/
 sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver, Lazarus v$lazarus_ver'/" ../../about.lfm
 
-lazbuild -B ../../transgui.lpi --lazarusdir=/Library/Lazarus/ --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa
+run_lazbuild
 
 # Building Intel version
 make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 "$lazdir"


### PR DESCRIPTION
## Summary

- Use a private Lazarus primary config path (PCP) for each macOS build.
- Clean generated `units/` and `lib/` output before building.
- Explicitly build `trcomp.lpk` before `transgui.lpi` in the same isolated PCP.
- Both `lazbuild` invocations use `-B`; the main project build may therefore recompile `trcomp` units when its package parameters differ.

## Root cause

The macOS job uses FPC 3.0.4 and Lazarus 2.0.8. It intermittently crashes inside the compiler with `EAccessViolation` while Lazarus processes the local `trcomp` package and its units.

The failure appears related to legacy Lazarus build state or partially generated outputs rather than a deterministic application-source failure. This change mitigates that state sensitivity through a combined approach: a private PCP isolates compiler state, clearing generated outputs removes stale artifacts, and the explicit package build provides a deterministic preflight before the main project build.

Because the main project is also built with `-B`, Lazarus may rebuild `trcomp` during the project build. The successful CI runs therefore validate the combined mitigation, but do not establish that package prebuilding alone is the decisive fix.

The Linux build already avoids this package-state path.

## Validation

- `sh -n setup/macosx/create_app_new.sh`
- `shellcheck setup/macosx/create_app_new.sh`
- `shfmt -sr -i 2 -ci -d setup/macosx/create_app_new.sh`
- Local Lazarus package build followed by project build using a private PCP with Lazarus 3.0 and FPC 3.2.2.
- macOS Cocoa CI validation passed with FPC 3.0.4 and Lazarus 2.0.8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes macOS Lazarus builds by isolating compiler state, resetting outputs, and prebuilding `trcomp` before the app to stop intermittent EAccessViolation crashes in CI.

- **Bug Fixes**
  - Use a per-build Lazarus PCP (`mktemp`), pass `--pcp` to both builds, and remove it on cleanup.
  - Require `lazbuild` at `lazarus_dir/lazbuild`; use it to get the Lazarus version and fail fast if missing.
  - Clear and recreate `units/` and `lib/` before each build; build `trcomp.lpk` before `transgui.lpi` with explicit `--lazarusdir`, `/usr/local/bin/fpc`, Cocoa, and x86_64 options.

<sup>Written for commit 82979a929a2ff7c3b764ecbdbaa146d5ec020ad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build reliability by consistently locating and validating required build tools.
  * Ensured configured settings are applied consistently during compilation.
  * Added temporary build-resource cleanup to prevent stale files from affecting future builds.
  * Improved compilation handling for both application and component packages.
  * Added build-tool version tracking to make build diagnostics more reliable.
<!-- end of auto-generated comment by coderabbit.ai -->