### PR TITLE
Add a reusable GTK2 startup smoke test to Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,17 @@ jobs:
 
           docker run "${docker_args[@]}" "${{ matrix.image }}" "${container_cmd[@]}"
 
+      - name: Smoke test GTK2 startup
+        if: matrix.arch == 'x86_64'
+        run: |
+          set -euo pipefail
+          docker run -e DEBIAN_FRONTEND=noninteractive --rm -v "${PWD}:/transgui" "${{ matrix.image }}" bash -c '
+            set -euo pipefail
+            apt-get update -yqq
+            apt-get install -yqq --no-install-recommends libgtk2.0-0 twm xvfb xdotool
+            exec /transgui/setup/unix/smoke_test_gtk2_startup.sh /transgui/transgui
+          '
+
       - name: Print checksums
         run: |
           set -euo pipefail

--- a/setup/unix/smoke_test_gtk2_startup.sh
+++ b/setup/unix/smoke_test_gtk2_startup.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../" && pwd)"
+
+if [ "$#" -gt 1 ]; then
+  echo "Usage: $0 [transgui-binary]" >&2
+  exit 2
+fi
+
+transgui_binary="${1:-$ROOT/transgui}"
+if [[ "$transgui_binary" != */* ]]; then
+  transgui_binary="./$transgui_binary"
+fi
+if [ ! -f "$transgui_binary" ] || [ ! -x "$transgui_binary" ]; then
+  echo "Transgui binary is not executable: $transgui_binary" >&2
+  exit 1
+fi
+transgui_binary="$(realpath "$transgui_binary")"
+transgui_ini="$(basename "$transgui_binary")"
+transgui_ini="${transgui_ini%.*}.ini"
+
+runtime_home="$(mktemp -d)"
+startup_log="$runtime_home/startup.log"
+wm_log="$runtime_home/wm.log"
+xvfb_log="$runtime_home/xvfb.log"
+export HOME="$runtime_home"
+
+printf "%s\n" \
+  "[MainForm]" \
+  "FirstRun=0" \
+  "" \
+  "[Connection]" \
+  "Host=127.0.0.1" \
+  "Port=1" \
+  "Autoreconnect=1" \
+  > "$runtime_home/$transgui_ini"
+printf "%s\n" "RandomPlacement" > "$runtime_home/.twmrc"
+
+xvfb_pid=""
+wm_pid=""
+app_pid=""
+
+process_alive() {
+  local pid="$1"
+  local stat_line
+
+  if ! kill -0 "$pid" 2> /dev/null; then
+    return 1
+  fi
+  if ! IFS= read -r stat_line < "/proc/$pid/stat"; then
+    return 1
+  fi
+
+  stat_line="${stat_line##*) }"
+  [ "${stat_line%% *}" != "Z" ]
+}
+
+stop_process() {
+  local pid="$1"
+  local name="$2"
+  local attempt
+
+  if [ -z "$pid" ]; then
+    return
+  fi
+  if ! process_alive "$pid"; then
+    wait "$pid" 2> /dev/null || true
+    return
+  fi
+
+  kill "$pid" 2> /dev/null || true
+  for ((attempt = 0; attempt < 20; attempt++)); do
+    if ! process_alive "$pid"; then
+      wait "$pid" 2> /dev/null || true
+      return
+    fi
+    sleep 0.1
+  done
+
+  kill -KILL "$pid" 2> /dev/null || true
+  for ((attempt = 0; attempt < 20; attempt++)); do
+    if ! process_alive "$pid"; then
+      wait "$pid" 2> /dev/null || true
+      return
+    fi
+    sleep 0.1
+  done
+
+  echo "$name did not exit after SIGKILL" >&2
+}
+
+cleanup() {
+  exit_status=$?
+  trap - EXIT
+  set +e
+  stop_process "$app_pid" "transgui"
+  stop_process "$wm_pid" "twm"
+  stop_process "$xvfb_pid" "Xvfb"
+  rm -rf "$runtime_home"
+  exit "$exit_status"
+}
+trap cleanup EXIT
+
+Xvfb :99 -screen 0 1280x800x24 > "$xvfb_log" 2>&1 &
+xvfb_pid=$!
+
+display_ready=0
+for _ in $(seq 1 100); do
+  if ! process_alive "$xvfb_pid"; then
+    echo "Xvfb exited during startup" >&2
+    cat "$xvfb_log" >&2
+    exit 1
+  fi
+  if DISPLAY=:99 xdotool getmouselocation > /dev/null 2>&1; then
+    display_ready=1
+    break
+  fi
+  sleep 0.1
+done
+
+if [ "$display_ready" -ne 1 ]; then
+  echo "Xvfb did not become ready" >&2
+  cat "$xvfb_log" >&2
+  exit 1
+fi
+
+DISPLAY=:99 twm > "$wm_log" 2>&1 &
+wm_pid=$!
+sleep 0.5
+if ! process_alive "$wm_pid"; then
+  echo "twm exited during startup" >&2
+  cat "$wm_log" >&2
+  exit 1
+fi
+
+DISPLAY=:99 G_DEBUG=fatal-criticals LIBOVERLAY_SCROLLBAR=0 \
+  "$transgui_binary" --home="$runtime_home" > "$startup_log" 2>&1 &
+app_pid=$!
+
+window_found=0
+for _ in $(seq 1 20); do
+  if ! process_alive "$wm_pid"; then
+    echo "twm exited during startup" >&2
+    cat "$wm_log" >&2
+    exit 1
+  fi
+  if ! process_alive "$app_pid"; then
+    echo "transgui exited during startup" >&2
+    cat "$startup_log" >&2
+    exit 1
+  fi
+  if DISPLAY=:99 timeout 1s xdotool search --onlyvisible \
+    --name "^Transmission Remote GUI v[0-9]" > /dev/null 2>&1; then
+    window_found=1
+    break
+  fi
+  sleep 0.5
+done
+
+if [ "$window_found" -ne 1 ]; then
+  echo "No visible transgui main window appeared" >&2
+  cat "$startup_log" >&2
+  cat "$wm_log" >&2
+  exit 1
+fi
+
+sleep 4
+if ! process_alive "$app_pid"; then
+  echo "transgui exited during startup" >&2
+  cat "$startup_log" >&2
+  exit 1
+fi
+
+if ! DISPLAY=:99 timeout 1s xdotool search --onlyvisible \
+  --name "^Transmission Remote GUI v[0-9]" > /dev/null 2>&1; then
+  echo "The transgui main window disappeared during startup" >&2
+  cat "$startup_log" >&2
+  cat "$wm_log" >&2
+  exit 1
+fi
+
+if visible_windows="$(DISPLAY=:99 timeout 1s xdotool search \
+  --onlyvisible --class Transgui)"; then
+  visible_window_count="$(wc -w <<< "$visible_windows")"
+else
+  search_status=$?
+  echo "Unable to inspect visible transgui windows (status $search_status)" >&2
+  cat "$startup_log" >&2
+  cat "$wm_log" >&2
+  exit 1
+fi
+if [ "$visible_window_count" -ne 1 ]; then
+  echo "Unexpected visible transgui window count: $visible_window_count" >&2
+  for window_id in $visible_windows; do
+    printf "%s: " "$window_id" >&2
+    DISPLAY=:99 xdotool getwindowname "$window_id" >&2 || true
+  done
+  cat "$startup_log" >&2
+  cat "$wm_log" >&2
+  exit 1
+fi
+
+if [ -s "$startup_log" ]; then
+  echo "Unexpected GTK2 startup output:" >&2
+  cat "$startup_log" >&2
+  exit 1
+fi


### PR DESCRIPTION
### **User description**
## Summary

- Add a reusable GTK2 startup smoke test to the native x86_64 Linux CI build.
- Keep the test logic in a ShellCheck-covered Unix helper and isolate the GTK2 runtime home.
- Require one visible main window, a live process, and no startup output while bounding child-process cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GTK2 startup smoke test to Linux CI to catch headless startup regressions. It runs `Transgui` under `Xvfb` + `twm`, requires one visible main window, a live process, and no startup output.

- **New Features**
  - Runs on `x86_64` in a Debian Bookworm container; installs `libgtk2.0-0`, `xvfb`, `twm`, `xdotool`.
  - Uses a standalone, ShellCheck-covered helper that isolates `HOME`, sets minimal `transgui.ini` and `.twmrc`, starts the display, then launches `/transgui/transgui` with `G_DEBUG=fatal-criticals` and `LIBOVERLAY_SCROLLBAR=0`.
  - Verifies exactly one visible `Transgui` main window persists and the process stays alive; fails on any stdout/stderr; prints X/WM logs and cleans up all child processes and temp files.

<sup>Written for commit dadabdbe208398f48d8027300338c20f3866bbac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Linux graphical startup smoke test for x86_64 systems.
  * Verifies the application launches successfully, displays exactly one main window, remains running, and produces no startup errors.
  * Automatically manages the test display environment and cleans up temporary processes and files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add reusable GTK2 graphical startup smoke test.

- Run GTK2 smoke test for x86_64 Linux CI.

- Validate window visibility, process health, and clean output.

- Isolate runtime settings and reliably clean child processes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Build["Built Transgui binary"]
  Container["x86_64 Linux CI container"]
  Smoke["GTK2 startup smoke-test helper"]
  Display["Xvfb and twm display"]
  Checks["Window, process, and output checks"]
  Build -- "mounted into" --> Container
  Container -- "runs" --> Smoke
  Smoke -- "starts" --> Display
  Smoke -- "validates" --> Checks
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smoke_test_gtk2_startup.sh</strong><dd><code>Add isolated GTK2 graphical startup smoke test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/unix/smoke_test_gtk2_startup.sh

<ul><li>Add a reusable Bash helper for GTK2 startup validation.<br> <li> Create an isolated temporary <code>HOME</code> and minimal app configuration.<br> <li> Start <code>Xvfb</code> and <code>twm</code>, then launch <code>transgui</code> headlessly.<br> <li> Require one visible main window, a live process, and empty startup <br>output.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1561/files#diff-bde644d171f6a97bcd4bdb23fad9e8cf719e1735d850456a3440395a98aedaa9">+209/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Run GTK2 smoke test in Linux CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add an x86_64-only GTK2 startup smoke-test CI step.<br> <li> Install GTK2 runtime, <code>Xvfb</code>, <code>twm</code>, and <code>xdotool</code> in the build container.<br> <li> Execute the reusable smoke-test helper against the built binary.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1561/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

