### PR TITLE
Upgrade macOS builds to Lazarus 2.2.6 and FPC 3.2.2

### DIFF
--- a/setup/macosx/create_app_new.sh
+++ b/setup/macosx/create_app_new.sh
@@ -2,17 +2,32 @@
 
 set -ex
 
+lazarus_dir="${1:-/Applications/Lazarus/}"
+lazbuild_bin="$lazarus_dir/lazbuild"
+if [ "${lazarus_dir%/}" != "/Applications/Lazarus" ] && [ ! -x "$lazbuild_bin" ]; then
+  echo "Unable to find lazbuild at $lazbuild_bin." >&2
+  exit 1
+fi
+
 prog_ver="$(cat ../../VERSION.txt)"
 build="$(git rev-list --abbrev-commit --max-count=1 HEAD ../..)"
-fpc_ver="$(fpc -i V | head -n 1)"
+
+if [ -z "${CI-}" ]; then
+  ./install_deps.sh
+fi
+
+fpc_bin="/usr/local/bin/fpc"
+if [ ! -x "$fpc_bin" ]; then
+  echo "Unable to find fpc at $fpc_bin." >&2
+  exit 1
+fi
+fpc_ver="Free Pascal Compiler version $("$fpc_bin" -iV)"
 exename=../../transgui
 appname="Transmission Remote GUI"
 dmg_dist_file="../../Release/transgui-$prog_ver.dmg"
 dmg_temp_file="$dmg_dist_file.tmp.dmg"
 dmgfolder=./Release
 appfolder="$dmgfolder/$appname.app"
-lazarus_dir="${1:-/Library/Lazarus/}"
-lazbuild_bin="$lazarus_dir/lazbuild"
 if [ ! -x "$lazbuild_bin" ]; then
   echo "Unable to find lazbuild at $lazbuild_bin." >&2
   exit 1
@@ -81,10 +96,6 @@ cleanup() {
   exit "$status"
 }
 
-if [ -z "${CI-}" ]; then
-  ./install_deps.sh
-fi
-
 if [ ! "$lazarus_dir" = "" ]; then
   lazdir=LAZARUS_DIR="$lazarus_dir"
 fi
@@ -114,8 +125,8 @@ cleanup_lazbuild_state() {
 
 run_lazbuild() {
   cleanup_lazbuild_state
-  "$lazbuild_bin" -B ../../trcomp.lpk --lazarusdir="$lazarus_dir" --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
-  "$lazbuild_bin" -B ../../transgui.lpi --lazarusdir="$lazarus_dir" --compiler=/usr/local/bin/fpc --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
+  "$lazbuild_bin" -B ../../trcomp.lpk --lazarusdir="$lazarus_dir" --compiler="$fpc_bin" --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
+  "$lazbuild_bin" -B ../../transgui.lpi --lazarusdir="$lazarus_dir" --compiler="$fpc_bin" --cpu=x86_64 --widgetset=cocoa --pcp="$lazarus_pcp"
 }
 
 mkdir -p ../../Release/
@@ -124,8 +135,8 @@ sed -i.bak "s/'Version %s'/'Version %s Build $build'#13#10'Compiled by: $fpc_ver
 run_lazbuild
 
 # Building Intel version
-make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 "$lazdir"
-make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 "$lazdir"
+make -j"$(sysctl -n hw.ncpu)" -C ../.. clean CPU_TARGET=x86_64 FPC="$fpc_bin" "$lazdir"
+make -j"$(sysctl -n hw.ncpu)" -C ../.. CPU_TARGET=x86_64 FPC="$fpc_bin" "$lazdir"
 
 if ! [ -e $exename ]; then
   echo "$exename does not exist"

--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -3,23 +3,56 @@
 set -x
 set -e
 
-lazarus_ver="2.0.8"
-fpc="fpc-3.0.4-macos-x86_64-laz-2"
-lazarus="LazarusIDE-2.0.8-macos-x86_64"
+lazarus_ver="2.2.6"
+fpc_ver="3.2.2"
+fpc="fpc-${fpc_ver}.intelarm64-macosx"
+lazarus="Lazarus-${lazarus_ver}-0-x86_64-macosx"
 sourceforge_base="https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}"
 download_attempts=3
 download_timeout="${download_timeout:-600}"
 download_backoff=5
+fpc_mount=""
+fpc_mounted=0
+fpc_downloaded=0
 
 if [ -n "${sourceforge_mirror-}" ]; then
   mirror_string="&use_mirror=${sourceforge_mirror}"
 fi
 
+detach_disk_image() {
+  detach_device=$1
+  detach_attempt=1
+
+  sync
+  while ! hdiutil detach "$detach_device"; do
+    if [ "$detach_attempt" -ge 5 ]; then
+      echo "Failed to detach $detach_device after $detach_attempt attempts." >&2
+      return 1
+    fi
+
+    echo "Failed to detach $detach_device; retrying in 2 seconds." >&2
+    sleep 2
+    detach_attempt=$((detach_attempt + 1))
+  done
+}
+
 cleanup_downloads() {
-  rm -f "fpc.pkg.part" "lazarus.pkg.part"
+  if [ "$fpc_mounted" -eq 1 ]; then
+    if detach_disk_image "$fpc_mount" > /dev/null; then
+      fpc_mounted=0
+    fi
+  fi
+  if [ "$fpc_mounted" -eq 0 ] && [ -n "$fpc_mount" ]; then
+    rmdir "$fpc_mount" > /dev/null 2>&1 || true
+  fi
+  if [ "$fpc_mounted" -eq 0 ] && [ "$fpc_downloaded" -eq 1 ]; then
+    rm -f "fpc.dmg" || true
+  fi
+  rm -f "fpc.dmg.part" "lazarus.pkg.part" || true
 }
 
 trap cleanup_downloads EXIT
+trap 'exit 1' HUP INT TERM
 
 download_url() {
   download_url_value="$1"
@@ -68,8 +101,11 @@ download_package() {
   download_url "$package_url" "$destination"
 }
 
-ppcx64_target="/usr/local/lib/fpc/3.0.4/ppcx64"
+ppcx64_target="/usr/local/lib/fpc/${fpc_ver}/ppcx64"
 ppcx64_link="/usr/local/bin/ppcx64"
+fpc_bin="/usr/local/bin/fpc"
+lazbuild_target="/Applications/Lazarus/lazbuild"
+lazbuild_link="/usr/local/bin/lazbuild"
 
 validate_ppcx64_link() {
   if [ -L "$ppcx64_link" ]; then
@@ -94,20 +130,61 @@ validate_ppcx64_link() {
   return 0
 }
 
-if [ ! -x "$(command -v fpc 2>&1)" ]; then
-  validate_ppcx64_link
-  download_package "$fpc.pkg" "fpc.pkg"
-  sudo installer -pkg "fpc.pkg" -target /
-  if [ ! -e "$ppcx64_link" ] && [ ! -L "$ppcx64_link" ]; then
-    sudo ln -s "$ppcx64_target" "$ppcx64_link"
-  else
+if [ ! -x "$fpc_bin" ] || [ "$("$fpc_bin" -iV)" != "$fpc_ver" ] || [ ! -x "$ppcx64_target" ]; then
+  if [ -e "$ppcx64_link" ] && [ ! -L "$ppcx64_link" ]; then
     validate_ppcx64_link
   fi
-  rm "fpc.pkg"
+  download_package "$fpc.dmg" "fpc.dmg"
+  fpc_downloaded=1
+  fpc_mount="$(mktemp -d "${TMPDIR:-/tmp}/transgui-fpc.XXXXXX")"
+  hdiutil attach -nobrowse -readonly -mountpoint "$fpc_mount" "fpc.dmg"
+  fpc_mounted=1
+  fpc_pkg="$fpc_mount/fpc-${fpc_ver}-intelarm64-macosx.mpkg"
+  if [ ! -e "$fpc_pkg" ]; then
+    echo "No installer package found in fpc.dmg" >&2
+    exit 1
+  fi
+  sudo installer -pkg "$fpc_pkg" -target /
+  detach_disk_image "$fpc_mount"
+  fpc_mounted=0
+  cleanup_downloads
 fi
 
-if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
+if [ ! -x "$ppcx64_target" ]; then
+  echo "$ppcx64_target is missing or is not executable" >&2
+  exit 1
+fi
+if ! validate_ppcx64_link; then
+  if [ ! -L "$ppcx64_link" ]; then
+    exit 1
+  fi
+  sudo rm "$ppcx64_link"
+fi
+if [ ! -L "$ppcx64_link" ]; then
+  sudo ln -s "$ppcx64_target" "$ppcx64_link"
+fi
+validate_ppcx64_link
+
+if [ ! -x "$lazbuild_target" ] || [ "$("$lazbuild_target" -v)" != "$lazarus_ver" ]; then
   download_package "$lazarus.pkg" "lazarus.pkg"
   sudo installer -pkg "lazarus.pkg" -target /
   rm "lazarus.pkg"
 fi
+
+if [ ! -x "$lazbuild_target" ]; then
+  echo "$lazbuild_target is missing or is not executable" >&2
+  exit 1
+fi
+if [ -e "$lazbuild_link" ] && [ ! -L "$lazbuild_link" ]; then
+  echo "$lazbuild_link exists and is not a symlink" >&2
+  exit 1
+fi
+if [ -L "$lazbuild_link" ] && [ "$(readlink "$lazbuild_link")" != "$lazbuild_target" ]; then
+  sudo rm "$lazbuild_link"
+fi
+if [ ! -L "$lazbuild_link" ]; then
+  sudo ln -s "$lazbuild_target" "$lazbuild_link"
+fi
+
+test "$("$fpc_bin" -iV)" = "$fpc_ver"
+test "$("$lazbuild_link" -v)" = "$lazarus_ver"


### PR DESCRIPTION
## Summary

- upgrade the macOS Intel Cocoa build from Lazarus 2.0.8 and FPC 3.0.4 to Lazarus 2.2.6 and FPC 3.2.2
- install the universal FPC distribution from its DMG and top-level mpkg
- verify the selected tool versions and repair the `ppcx64` link across upgrades and interrupted runs

## Why

Linux builds already use Lazarus 2.2.6 and FPC 3.2.2. Aligning the macOS build removes the older compiler baseline without changing the Cocoa target, architecture, or DMG packaging flow.

## Validation

- `sh -n setup/macosx/install_deps.sh`
- ShellCheck for all repository shell scripts
- shfmt for all repository shell scripts
- shfmt with the CI image `peterdavehello/shfmt:3.4.0`
- Docker mock coverage for a 3.0.4 upgrade, a clean re-run, detach retries, persistent detach failure, interrupted post-install recovery, and a missing mpkg
- local multi-review loop with CodeRabbit, Claude, OpenCode, Cline, Kilo, and Grok; Kilo's final follow-up was unavailable because of an upstream service error

The GitHub macOS job provides the real Intel runner installation and application build validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the macOS Intel Cocoa build to `Lazarus` 2.2.6 and `FPC` 3.2.2 to match Linux. Install `FPC` from a DMG with read-only mounts, retries, and cleanup, and use `/usr/local/bin/fpc` for all build steps; Cocoa x86_64 target and packaging stay the same.

- **Dependencies**
  - Install universal `FPC` 3.2.2 via the DMG’s top-level `.mpkg`; read-only mount, retry detach, and clean temp files.
  - Update `Lazarus` to 2.2.6 with version checks; verify `fpc -iV`/`lazbuild -v`; pass `/usr/local/bin/fpc` to `lazbuild` and `make`; run `install_deps.sh` outside CI.
  - Default `lazbuild` to `/Applications/Lazarus/`, allow `lazarus_dir` override, and symlink `/usr/local/bin/lazbuild`.

- **Bug Fixes**
  - Validate and repair `/usr/local/bin/ppcx64`; ensure `/usr/local/lib/fpc/3.2.2/ppcx64` exists.
  - Add safe cleanup on exit and signals for DMG mounts and temp files.
  - Fail fast on conflicting or non-symlink `lazbuild` and bad `ppcx64` links; verify `/usr/local/bin/fpc` exists before build.

<sup>Written for commit 9612d6ab915abf6d7c0723be15f2f54b5b9ecc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS development tools to Lazarus 2.2.6 and Free Pascal Compiler 3.2.2.
  * Improved installation reliability with package validation, retry handling, cleanup, and support for Intel and ARM Macs.
  * Added validation for installed compiler and Lazarus versions, including automatic repair of valid command links.
  * Improved macOS build setup by using the verified compiler installation and skipping redundant dependency setup in CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->