### PR TITLE
Prevent FilterTimer from firing before RPC initialization

### DIFF
--- a/main.lfm
+++ b/main.lfm
@@ -4975,6 +4975,7 @@ inherited MainForm: TMainForm
     end
   end
   object FilterTimer: TTimer[21]
+    Enabled = False
     Interval = 100
     OnTimer = FilterTimerTimer
     left = 76


### PR DESCRIPTION
GTK2 may dispatch timer events while TMainForm is still being created. FilterTimer can then call DoRefresh before RpcObj is assigned, causing an access violation.

Keep the timer disabled until lvFilterClick explicitly enables it, preserving the existing 100 ms debounce behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable FilterTimer at startup to prevent DoRefresh from running before the RPC object is initialized on GTK2, avoiding access violations. The timer is now enabled by lvFilterClick, keeping the 100 ms debounce behavior intact.

<sup>Written for commit cd40e5c4fca983b33c514885feec2399ec85a665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

