### PR TITLE
Add Windows packaging coverage to CI

### DIFF
--- a/.github/scripts/build-windows.ps1
+++ b/.github/scripts/build-windows.ps1
@@ -1,0 +1,321 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [ValidateSet('x86', 'x86_64')]
+  [string]$Architecture,
+
+  [string]$LazarusDir = 'C:\lazarus',
+
+  [string]$InnoSetupDir = 'C:\Program Files (x86)\Inno Setup 5'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+function Invoke-CheckedCommand {
+  param(
+    [Parameter(Mandatory)]
+    [string]$FilePath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  Write-Host "> $FilePath $($ArgumentList -join ' ')"
+  & $FilePath @ArgumentList
+  if ($LASTEXITCODE -ne 0) {
+    throw "Command failed with exit code ${LASTEXITCODE}: $FilePath"
+  }
+}
+
+function Invoke-CheckedProcess {
+  param(
+    [Parameter(Mandatory)]
+    [string]$FilePath,
+
+    [string[]]$ArgumentList = @()
+  )
+
+  Write-Host "> $FilePath $($ArgumentList -join ' ')"
+  $process = Start-Process `
+    -FilePath $FilePath `
+    -ArgumentList $ArgumentList `
+    -PassThru `
+    -Wait
+  if ($process.ExitCode -ne 0) {
+    throw "Process failed with exit code $($process.ExitCode): $FilePath"
+  }
+}
+
+function Invoke-PackagingScript {
+  param(
+    [Parameter(Mandatory)]
+    [string]$FilePath
+  )
+
+  Push-Location (Split-Path -Parent $FilePath)
+  try {
+    Invoke-CheckedCommand $FilePath
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+function Assert-Artifact {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Path,
+
+    [Parameter(Mandatory)]
+    [version]$ExpectedVersion,
+
+    [uint16]$ExpectedMachine = 0,
+
+    [switch]$RequireUpx
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Expected file was not produced: $Path"
+  }
+
+  $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($Path)
+  $actualVersion = [version]::new(
+    $versionInfo.FileMajorPart,
+    $versionInfo.FileMinorPart,
+    $versionInfo.FileBuildPart,
+    $versionInfo.FilePrivatePart
+  )
+  $normalizedVersion = [version]::new(
+    $ExpectedVersion.Major,
+    $ExpectedVersion.Minor,
+    [Math]::Max($ExpectedVersion.Build, 0),
+    [Math]::Max($ExpectedVersion.Revision, 0)
+  )
+  if ($actualVersion -ne $normalizedVersion) {
+    throw "$Path has file version $actualVersion, expected $normalizedVersion"
+  }
+
+  $signature = Get-AuthenticodeSignature -LiteralPath $Path
+  if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned) {
+    throw "$Path unexpectedly has Authenticode status $($signature.Status)"
+  }
+
+  if ($ExpectedMachine -ne 0) {
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    if (
+      $bytes.Length -lt 64 -or
+      [BitConverter]::ToUInt16($bytes, 0) -ne 0x5A4D
+    ) {
+      throw "$Path does not have a valid DOS header"
+    }
+
+    $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+    if (
+      $peOffset -lt 0 -or
+      $peOffset + 6 -gt $bytes.Length -or
+      [BitConverter]::ToUInt32($bytes, $peOffset) -ne 0x00004550
+    ) {
+      throw "$Path does not have a valid PE header"
+    }
+
+    $actualMachine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+    if ($actualMachine -ne $ExpectedMachine) {
+      throw (
+        '{0} has PE machine type 0x{1:X4}, expected 0x{2:X4}' -f
+        $Path,
+        $actualMachine,
+        $ExpectedMachine
+      )
+    }
+  }
+
+  if ($RequireUpx) {
+    Invoke-CheckedCommand $script:upx @('-t', $Path)
+  }
+}
+
+function Assert-PathRemoved {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Path
+  )
+
+  foreach ($attempt in 1..40) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  }
+  throw "Path was not removed: $Path"
+}
+
+function Restore-EnvironmentVariable {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Name,
+
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ($null -eq $Value) {
+    Remove-Item "Env:$Name" -ErrorAction SilentlyContinue
+  }
+  else {
+    Set-Item -Path "Env:$Name" -Value $Value
+  }
+}
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$versionText = (
+  Get-Content -LiteralPath (Join-Path $repositoryRoot 'VERSION.txt') -TotalCount 1
+).Trim()
+if ([string]::IsNullOrWhiteSpace($versionText)) {
+  throw 'VERSION.txt did not contain a version'
+}
+$version = [version]::Parse($versionText)
+
+switch ($Architecture) {
+  'x86' {
+    $fpcTarget = 'i386-win32'
+    $setupDirectory = 'setup\win'
+    $expectedMachine = [uint16]0x014C
+    $installerName = "transgui-$versionText-setup.exe"
+  }
+  'x86_64' {
+    $fpcTarget = 'x86_64-win64'
+    $setupDirectory = 'setup\win_amd64'
+    $expectedMachine = [uint16]0x8664
+    $installerName = "transgui-$versionText-setup_64bit.exe"
+  }
+}
+
+$lazbuild = Join-Path $LazarusDir 'lazbuild.exe'
+$setupPath = Join-Path $repositoryRoot $setupDirectory
+$makeSetupScript = Join-Path $setupPath 'make_setup.bat'
+$makeZipdistScript = Join-Path $setupPath 'make_zipdist.bat'
+$script:upx = (Get-Command 'upx.exe' -CommandType Application -ErrorAction Stop).Source
+$zip = (Get-Command 'zip.exe' -CommandType Application -ErrorAction Stop).Source
+
+foreach ($requiredFile in @(
+  $lazbuild,
+  (Join-Path $InnoSetupDir 'ISCC.exe'),
+  $script:upx,
+  $zip,
+  $makeSetupScript,
+  $makeZipdistScript
+)) {
+  if (-not (Test-Path -LiteralPath $requiredFile -PathType Leaf)) {
+    throw "Required build tool or script was not found: $requiredFile"
+  }
+}
+
+$originalEnvironment = [ordered]@{
+  CI = $env:CI
+  CODECERT = $env:CODECERT
+  ISC = $env:ISC
+  LAZARUS_DIR = $env:LAZARUS_DIR
+  LAZARUS_PCP = $env:LAZARUS_PCP
+}
+
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { $env:TEMP }
+$primaryConfigPath = Join-Path $tempRoot "lazarus-pcp-transgui-$Architecture"
+$portableTestPath = Join-Path $tempRoot "transgui-portable-$Architecture"
+$installerTestPath = Join-Path $tempRoot "transgui-installer-$Architecture"
+$installerLog = Join-Path $tempRoot "transgui-installer-$Architecture.log"
+
+$env:CI = 'true'
+$env:ISC = $InnoSetupDir
+$env:LAZARUS_DIR = $LazarusDir
+$env:LAZARUS_PCP = $primaryConfigPath
+Remove-Item Env:CODECERT -ErrorAction SilentlyContinue
+
+foreach ($path in @(
+  $primaryConfigPath,
+  $portableTestPath,
+  $installerTestPath,
+  (Join-Path $repositoryRoot 'units'),
+  (Join-Path $repositoryRoot 'lib'),
+  (Join-Path $repositoryRoot 'Release'),
+  (Join-Path $repositoryRoot 'transgui.exe')
+)) {
+  Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+}
+Remove-Item -LiteralPath $installerLog -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $primaryConfigPath | Out-Null
+
+try {
+  Invoke-PackagingScript $makeSetupScript
+
+  $releaseDirectory = Join-Path $repositoryRoot 'Release'
+  $installer = Join-Path $releaseDirectory $installerName
+  Assert-Artifact $installer $version
+
+  Invoke-CheckedProcess $installer @(
+    '/VERYSILENT',
+    '/SUPPRESSMSGBOXES',
+    '/NORESTART',
+    '/SP-',
+    '/TYPE=compact',
+    '/TASKS=',
+    ('/DIR="{0}"' -f $installerTestPath),
+    ('/LOG="{0}"' -f $installerLog)
+  )
+
+  $installedExecutable = Join-Path $installerTestPath 'transgui.exe'
+  Assert-Artifact $installedExecutable $version $expectedMachine
+
+  $uninstallers = @(
+    Get-ChildItem -LiteralPath $installerTestPath -Filter 'unins*.exe' -File
+  )
+  if ($uninstallers.Count -ne 1) {
+    throw "Expected exactly one uninstaller; found $($uninstallers.Count)"
+  }
+  Invoke-CheckedProcess $uninstallers[0].FullName @(
+    '/VERYSILENT',
+    '/SUPPRESSMSGBOXES',
+    '/NORESTART'
+  )
+  Assert-PathRemoved $installedExecutable
+
+  Invoke-PackagingScript $makeZipdistScript
+
+  $portableArchive = Join-Path (
+    Join-Path $repositoryRoot 'Release'
+  ) "transgui-$versionText-$fpcTarget.zip"
+  if (-not (Test-Path -LiteralPath $portableArchive -PathType Leaf)) {
+    throw "Expected portable archive was not produced: $portableArchive"
+  }
+
+  Expand-Archive -LiteralPath $portableArchive -DestinationPath $portableTestPath
+  Assert-Artifact `
+    (Join-Path $portableTestPath 'transgui.exe') `
+    $version `
+    $expectedMachine `
+    -RequireUpx
+
+  Get-Item -LiteralPath $installer, $portableArchive |
+    Format-Table FullName, Length, LastWriteTimeUtc -AutoSize
+}
+catch {
+  if (Test-Path -LiteralPath $installerLog -PathType Leaf) {
+    Write-Host '--- Inno Setup log ---'
+    Get-Content -LiteralPath $installerLog | ForEach-Object { Write-Host $_ }
+  }
+  throw
+}
+finally {
+  foreach ($path in @(
+    $primaryConfigPath,
+    $portableTestPath,
+    $installerTestPath
+  )) {
+    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  Remove-Item -LiteralPath $installerLog -Force -ErrorAction SilentlyContinue
+
+  foreach ($entry in $originalEnvironment.GetEnumerator()) {
+    Restore-EnvironmentVariable $entry.Key $entry.Value
+  }
+}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,109 @@
+name: Windows CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-build:
+    name: Build / Windows / ${{ matrix.arch }}
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - x86
+          - x86_64
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+
+          $lazarusArgs = @(
+            'install',
+            'lazarus',
+            '--version=2.2.6',
+            '--yes',
+            '--no-progress'
+          )
+          if ('${{ matrix.arch }}' -eq 'x86') {
+            $lazarusArgs += '--x86'
+          }
+
+          & choco @lazarusArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install Lazarus: $LASTEXITCODE"
+          }
+
+          & choco install innosetup `
+            --version=5.6.1 `
+            --allow-downgrade `
+            --yes `
+            --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install Inno Setup: $LASTEXITCODE"
+          }
+
+          & choco install inno-download-plugin `
+            --version=1.5.1 `
+            --yes `
+            --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install Inno Download Plugin: $LASTEXITCODE"
+          }
+
+          & choco install zip `
+            --version=3.0.0.20251001 `
+            --yes `
+            --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install zip: $LASTEXITCODE"
+          }
+
+          & choco install upx `
+            --version=5.2.0 `
+            --yes `
+            --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install UPX: $LASTEXITCODE"
+          }
+
+      - name: Build and test Windows artifacts
+        shell: pwsh
+        run: .\.github\scripts\build-windows.ps1 -Architecture '${{ matrix.arch }}'
+
+      - name: Print SHA-256 checksums
+        shell: pwsh
+        run: |
+          Get-ChildItem Release -File |
+            Sort-Object Name |
+            ForEach-Object {
+              $hash = Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256
+              '{0}  {1}' -f $hash.Hash.ToLowerInvariant(), $_.Name
+            }
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: transgui-windows-${{ matrix.arch }}
+          path: |
+            Release/transgui-*.zip
+            Release/transgui-*-setup*.exe
+          if-no-files-found: error

--- a/setup/win/make_setup.bat
+++ b/setup/win/make_setup.bat
@@ -4,23 +4,32 @@ echo "Usage: %~nx0 <lazarus_dir> <inno_setup_dir>"
 
 if "%1" NEQ "" (
     set "LAZARUS_DIR=%1"
-) else (
+) else if not defined LAZARUS_DIR (
     set "LAZARUS_DIR=C:\lazarus"
 )
 
 if "%2" NEQ "" (
     set "ISC=%2"
-) else (
+) else if not defined ISC (
     set "ISC=C:\Program Files (x86)\Inno Setup 5"
 )
 
 set path=%LAZARUS_DIR%;%LAZARUS_DIR%\fpc\3.2.2\bin\i386-win32;%path%
+set "PROG_VER="
+set /p "PROG_VER="<..\..\VERSION.txt
+if not defined PROG_VER goto err
 
-lazbuild -B ../../transgui.lpi
+if defined LAZARUS_PCP (
+    lazbuild -B ../../trcomp.lpk "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+    if errorlevel 1 goto err
+    lazbuild -B ../../transgui.lpi "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+) else (
+    lazbuild -B ../../transgui.lpi
+)
 if errorlevel 1 goto err
-make -C ../.. clean
+make "PROG_VER=%PROG_VER%" -C ../.. clean
 if errorlevel 1 goto err
-make -C ../.. all
+make "PROG_VER=%PROG_VER%" -C ../.. all
 if errorlevel 1 goto err
 
 if not (%CODECERT%) == () (
@@ -28,12 +37,12 @@ if not (%CODECERT%) == () (
   if errorlevel 1 goto err
 )
 
-"%ISC%\iscc.exe" "/ssigntool=signtool.exe $p" setup.iss
+"%ISC%\iscc.exe" "/DAppVersion=%PROG_VER%" "/ssigntool=signtool.exe $p" setup.iss
 if errorlevel 1 goto err
 
-pause
+if not defined CI pause
 exit /b 0
 
 :err
-pause
+if not defined CI pause
 exit /b 1

--- a/setup/win/make_zipdist.bat
+++ b/setup/win/make_zipdist.bat
@@ -4,26 +4,35 @@ echo "Usage: %~nx0 <lazarus_dir>"
 
 if "%1" NEQ "" (
     set "LAZARUS_DIR=%1"
-) else (
+) else if not defined LAZARUS_DIR (
     set "LAZARUS_DIR=C:\lazarus"
 )
 
 set path=%LAZARUS_DIR%;%LAZARUS_DIR%\fpc\3.2.2\bin\i386-win32;%path%
+set "PROG_VER="
+set /p "PROG_VER="<..\..\VERSION.txt
+if not defined PROG_VER goto err
 
-lazbuild -B ../../transgui.lpi
+if defined LAZARUS_PCP (
+    lazbuild -B ../../trcomp.lpk "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+    if errorlevel 1 goto err
+    lazbuild -B ../../transgui.lpi "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+) else (
+    lazbuild -B ../../transgui.lpi
+)
 if errorlevel 1 goto err
-make -C ../.. clean
+make "PROG_VER=%PROG_VER%" -C ../.. clean
 if errorlevel 1 goto err
-make -C ../.. all
+make "PROG_VER=%PROG_VER%" -C ../.. all
 if errorlevel 1 goto err
 upx --best ../../transgui.exe
 if errorlevel 1 goto err
-make -C ../.. zipdist
+make "PROG_VER=%PROG_VER%" -C ../.. zipdist
 if errorlevel 1 goto err
 
-pause
+if not defined CI pause
 exit /b 0
 
 :err
-pause
+if not defined CI pause
 exit /b 1

--- a/setup/win_amd64/make_setup.bat
+++ b/setup/win_amd64/make_setup.bat
@@ -4,23 +4,32 @@ echo "Usage: %~nx0 <lazarus_dir> <inno_setup_dir>"
 
 if "%1" NEQ "" (
     set "LAZARUS_DIR=%1"
-) else (
+) else if not defined LAZARUS_DIR (
     set "LAZARUS_DIR=C:\lazarus"
 )
 
 if "%2" NEQ "" (
     set "ISC=%2"
-) else (
+) else if not defined ISC (
     set "ISC=C:\Program Files (x86)\Inno Setup 5"
 )
 
 set path=%LAZARUS_DIR%;%LAZARUS_DIR%\fpc\3.2.2\bin\x86_64-win64;%path%
+set "PROG_VER="
+set /p "PROG_VER="<..\..\VERSION.txt
+if not defined PROG_VER goto err
 
-lazbuild -B ../../transgui.lpi
+if defined LAZARUS_PCP (
+    lazbuild -B ../../trcomp.lpk "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+    if errorlevel 1 goto err
+    lazbuild -B ../../transgui.lpi "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+) else (
+    lazbuild -B ../../transgui.lpi
+)
 if errorlevel 1 goto err
-make -C ../.. clean
+make "PROG_VER=%PROG_VER%" -C ../.. clean
 if errorlevel 1 goto err
-make -C ../.. all
+make "PROG_VER=%PROG_VER%" -C ../.. all
 if errorlevel 1 goto err
 
 if not (%CODECERT%) == () (
@@ -28,12 +37,12 @@ if not (%CODECERT%) == () (
   if errorlevel 1 goto err
 )
 
-"%ISC%\iscc.exe" "/ssigntool=signtool.exe $p" setup.iss
+"%ISC%\iscc.exe" "/DAppVersion=%PROG_VER%" "/ssigntool=signtool.exe $p" setup.iss
 if errorlevel 1 goto err
 
-pause
+if not defined CI pause
 exit /b 0
 
 :err
-pause
+if not defined CI pause
 exit /b 1

--- a/setup/win_amd64/make_zipdist.bat
+++ b/setup/win_amd64/make_zipdist.bat
@@ -4,26 +4,35 @@ echo "Usage: %~nx0 <lazarus_dir>"
 
 if "%1" NEQ "" (
     set "LAZARUS_DIR=%1"
-) else (
+) else if not defined LAZARUS_DIR (
     set "LAZARUS_DIR=C:\lazarus"
 )
 
 set path=%LAZARUS_DIR%;%LAZARUS_DIR%\fpc\3.2.2\bin\x86_64-win64;%path%
+set "PROG_VER="
+set /p "PROG_VER="<..\..\VERSION.txt
+if not defined PROG_VER goto err
 
-lazbuild -B ../../transgui.lpi
+if defined LAZARUS_PCP (
+    lazbuild -B ../../trcomp.lpk "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+    if errorlevel 1 goto err
+    lazbuild -B ../../transgui.lpi "--lazarusdir=%LAZARUS_DIR%" "--pcp=%LAZARUS_PCP%"
+) else (
+    lazbuild -B ../../transgui.lpi
+)
 if errorlevel 1 goto err
-make -C ../.. clean
+make "PROG_VER=%PROG_VER%" -C ../.. clean
 if errorlevel 1 goto err
-make -C ../.. all
+make "PROG_VER=%PROG_VER%" -C ../.. all
 if errorlevel 1 goto err
 upx --best ../../transgui.exe
 if errorlevel 1 goto err
-make -C ../.. zipdist
+make "PROG_VER=%PROG_VER%" -C ../.. zipdist
 if errorlevel 1 goto err
 
-pause
+if not defined CI pause
 exit /b 0
 
 :err
-pause
+if not defined CI pause
 exit /b 1


### PR DESCRIPTION
### **User description**
## Why

Windows is a primary release platform, but the existing CI builds only Linux and macOS. Windows compiler, widgetset, portable-package, and installer regressions can therefore remain undetected until manual release work.

The existing Windows packaging paths also derive versions differently: GNU make can fail to execute the `cmd.exe`-only `type VERSION.txt` lookup, while the Inno Setup fallback shortens the executable version `5.18.0.0` to `5.18`. That can leave ZIP names unversioned or make installer and ZIP versions disagree with `VERSION.txt`.

## What changed

- add Windows 2022 CI jobs for x86 and x86_64;
- run the existing architecture-specific `make_setup.bat` and `make_zipdist.bat` entry points directly rather than duplicating their build logic in the workflow;
- use `VERSION.txt` as the package version passed to GNU make and Inno Setup;
- verify executable architecture and version metadata, unsigned CI output, UPX integrity for portable packages, archive contents, and silent installer installation/removal;
- upload the installer and portable ZIP using the repository's default artifact-retention policy.

## Necessary release-script adjustments

The four existing Windows batch files are changed only where required to make the real maintainer-facing packaging paths testable and version-consistent:

- preserve their positional tool-path arguments and existing defaults, while also allowing CI to provide the same paths through environment variables;
- accept an isolated `LAZARUS_PCP`; when one is supplied, build `trcomp.lpk` into that profile before building the application;
- suppress `pause` only when `CI` is defined;
- read `VERSION.txt` once and pass that value as `PROG_VER`, plus `/DAppVersion` for installers.

The PowerShell validator supplies these CI-only inputs, restores the process variables it changes, and does not rewrite tracked Makefiles or modify `PATH`.

## Scope boundaries

This does not change application behavior, `Makefile` / `Makefile.fpc`, Inno Setup definitions, signing credentials, release publication, or the existing packaging policy: installers contain the normal executable and portable ZIPs contain the UPX-compressed executable.

## Verification

- [x] Windows x86 full build, installer smoke test, and portable-package validation
- [x] Windows x86_64 full build, installer smoke test, and portable-package validation
- [x] Existing static, Linux, and macOS CI


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Add Windows x86 and x64 packaging CI.

- Validate installers and portable ZIP artifacts.

- Align package versions with `VERSION.txt`.

- Support isolated Lazarus profiles in packaging scripts.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Workflow["Windows CI matrix"]
  Scripts["Windows packaging scripts"]
  Validator["Artifact validation"]
  Releases["Installer and ZIP artifacts"]
  Workflow -- "runs" --> Validator
  Validator -- "invokes" --> Scripts
  Scripts -- "produces" --> Releases
  Validator -- "verifies" --> Releases
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>make_setup.bat</strong><dd><code>Make x86 installer packaging CI-compatible</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/win/make_setup.bat

<ul><li>Preserve environment-provided <code>LAZARUS_DIR</code> and <code>ISC</code> paths.<br> <li> Read <code>VERSION.txt</code> and forward <code>PROG_VER</code> to make and Inno Setup.<br> <li> Build <code>trcomp.lpk</code> when an isolated <code>LAZARUS_PCP</code> is supplied.<br> <li> Skip interactive pauses when running under <code>CI</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-eff7d7cb30ed8f23cea5ae847827ef6ecaaf47e64c43202fa81e4e0fcf318b8c">+18/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>make_zipdist.bat</strong><dd><code>Make x86 ZIP packaging CI-compatible</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/win/make_zipdist.bat

<ul><li>Preserve an environment-provided <code>LAZARUS_DIR</code>.<br> <li> Pass the <code>VERSION.txt</code> value to all make invocations.<br> <li> Support isolated Lazarus profiles and prerequisite package builds.<br> <li> Avoid pauses during non-interactive CI runs.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-7a0af770536bea091e2a0d19f40bda530bf15c198976749b97bc022d63057640">+16/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>make_setup.bat</strong><dd><code>Make x64 installer packaging CI-compatible</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/win_amd64/make_setup.bat

<ul><li>Preserve environment-provided Lazarus and Inno Setup locations.<br> <li> Source installer and build versioning from <code>VERSION.txt</code>.<br> <li> Build <code>trcomp.lpk</code> before application builds under <code>LAZARUS_PCP</code>.<br> <li> Suppress pauses only when <code>CI</code> is defined.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-36c093181af6a998ca38cb286ee3700c97ba40b66bc1760b14579957262542f9">+18/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>make_zipdist.bat</strong><dd><code>Make x64 ZIP packaging CI-compatible</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/win_amd64/make_zipdist.bat

<ul><li>Retain environment-provided Lazarus path configuration.<br> <li> Pass the canonical version into make packaging commands.<br> <li> Build required Lazarus package for isolated profiles.<br> <li> Disable prompts for CI execution.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-ee132e69344ad4202ff174726a8f32a3282b02356d2b7959da973d0594c35f47">+16/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-windows.ps1</strong><dd><code>Validate Windows packages across both architectures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/build-windows.ps1

<ul><li>Invoke architecture-specific installer and ZIP packaging scripts.<br> <li> Validate executable versions, PE architecture, signatures, and UPX <br>integrity.<br> <li> Silently install and uninstall generated installer artifacts.<br> <li> Isolate Lazarus configuration and restore modified environment <br>variables.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-b325581b56125899f33c6e76cb17244ccffc02015475f3ad828fe24a42ea445c">+321/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>windows-ci.yml</strong><dd><code>Add Windows packaging build matrix workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/windows-ci.yml

<ul><li>Add Windows Server 2022 CI for x86 and x86_64.<br> <li> Install pinned Lazarus, Inno Setup, ZIP, and UPX dependencies.<br> <li> Run packaging validation and print artifact checksums.<br> <li> Upload installer and portable ZIP build artifacts.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1564/files#diff-20657aa6e437cb522fb4623a03fc7ec7c4343e2c08288cfd4c2c2755967a0d37">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Windows CI builds for x86 and x86_64 platforms.
  * Build pipelines now produce installers and portable ZIP packages.
  * Generated artifacts include SHA-256 checksums for verification.

* **Bug Fixes**
  * Windows packaging now consistently uses version information from `VERSION.txt`.
  * Improved handling of build failures and CI execution without unnecessary pauses.

* **Validation**
  * Installers and portable builds are checked for architecture, version, integrity, and successful installation and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->