### PR TITLE
Handle malformed session statistics safely

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -736,6 +736,7 @@ type
     function DoConnect: boolean;
     procedure DoCreateOutZipStream(Sender: TObject; var AStream: TStream; AItem: TFullZipFileEntry);
     procedure DoDisconnect;
+    procedure ClearStatistics;
     procedure DoOpenFlagsZip(Sender: TObject; var AStream: TStream);
     procedure TorrentProps(PageNo: integer);
     procedure ShowConnOptions(NewConnection: boolean);
@@ -802,8 +803,8 @@ type
     procedure FillGeneralInfo(t: TJSONObject);
     procedure FillTrackersList(TrackersData: TJSONObject);
     procedure FillSessionInfo(s: TJSONObject);
-    procedure FillStatistics(s: TJSONObject);
-    procedure CheckStatus(Fatal: boolean = True);
+    function FillStatistics(s: TJSONObject): boolean;
+    procedure CheckStatus(Fatal: boolean = True; const AStatus: string = '');
     function TorrentAction(const TorrentIds: variant; const AAction: string; args: TJSONObject = nil): boolean;
     function SetFilePriority(TorrentId: integer; const Files: array of integer; const APriority: string): boolean;
     function SetCurrentFilePriority(const APriority: string): boolean;
@@ -5280,8 +5281,6 @@ begin
 end;
 
 procedure TMainForm.DoDisconnect;
-var
-  i: integer;
 begin
   TorrentsListTimer.Enabled:=False;
   FilterTimer.Enabled:=False;
@@ -5312,19 +5311,7 @@ begin
   edSearch.Color:=gTorrents.Color;
   edSearch.Text:='';
 
-  with gStats do begin
-    BeginUpdate;
-    try
-      for i:=0 to Items.Count - 1 do begin
-        Items[1, i]:=NULL;
-        Items[2, i]:=NULL;
-      end;
-    finally
-      EndUpdate;
-    end;
-    Enabled:=False;
-    Color:=gTorrents.Color;
-  end;
+  ClearStatistics;
 
   RpcObj.Disconnect;
 
@@ -5344,6 +5331,25 @@ begin
   FCurUpSpeedLimit:=-2;
   FillSpeedsMenu;
   tbConnect.Caption := Format(SConnectTo,['Transmission']);
+end;
+
+procedure TMainForm.ClearStatistics;
+var
+  i: integer;
+begin
+  with gStats do begin
+    BeginUpdate;
+    try
+      for i:=0 to Items.Count - 1 do begin
+        Items[1, i]:=NULL;
+        Items[2, i]:=NULL;
+      end;
+    finally
+      EndUpdate;
+    end;
+    Enabled:=False;
+    Color:=clBtnFace;
+  end;
 end;
 
 procedure TMainForm.ClearDetailsInfo(Skip: TAdvInfoType);
@@ -7081,46 +7087,134 @@ begin
 {$endif LCLcarbon}
 end;
 
-procedure TMainForm.FillStatistics(s: TJSONObject);
+function TMainForm.FillStatistics(s: TJSONObject): boolean;
+type
+  TStatistics = record
+    DownloadedBytes: double;
+    UploadedBytes: double;
+    FilesAdded: integer;
+    SecondsActive: integer;
+  end;
+var
+  currentStats, cumulativeStats: TStatistics;
 
-  procedure _Fill(idx: integer; s: TJSONObject);
+  function _GetNumber(stats: TJSONObject; const name: string; out value: double): boolean;
+  var
+    idx: integer;
+    d: TJSONData;
+  begin
+    Result:=False;
+    idx:=stats.IndexOfName(name);
+    if idx < 0 then
+      exit;
+    d:=stats.Items[idx];
+    if d.JSONType <> jtNumber then
+      exit;
+    try
+      value:=d.AsFloat;
+      Result:=(value >= 0) and not IsNan(value) and not IsInfinite(value);
+    except
+      Result:=False;
+    end;
+  end;
+
+  function _GetInteger(stats: TJSONObject; const name: string; out value: integer;
+    maxValue: integer = High(integer)): boolean;
+  var
+    idx: integer;
+    d: TJSONData;
+    n: double;
+  begin
+    Result:=False;
+    idx:=stats.IndexOfName(name);
+    if idx < 0 then
+      exit;
+    d:=stats.Items[idx];
+    if not (d is TJSONNumber) then
+      exit;
+    if d is TJSONFloatNumber then
+      exit;
+    Result:=_GetNumber(stats, name, n);
+    if not Result then
+      exit;
+    Result:=n <= maxValue;
+    if Result then
+      value:=Trunc(n);
+  end;
+
+  function _GetStats(const name: string; out values: TStatistics): boolean;
+  var
+    idx: integer;
+    stats: TJSONObject;
+    d: TJSONData;
+  begin
+    Result:=False;
+    idx:=s.IndexOfName(name);
+    if idx < 0 then
+      exit;
+    d:=s.Items[idx];
+    if not (d is TJSONObject) then
+      exit;
+    stats:=d as TJSONObject;
+    Result:=_GetNumber(stats, 'downloadedBytes', values.DownloadedBytes) and
+      _GetNumber(stats, 'uploadedBytes', values.UploadedBytes) and
+      _GetInteger(stats, 'filesAdded', values.FilesAdded) and
+      _GetInteger(stats, 'secondsActive', values.SecondsActive, High(integer) - 30);
+  end;
+
+  procedure _Fill(idx: integer; const values: TStatistics);
   begin
     with gStats do begin
-      Items[idx, 0]:=UTF8Decode(GetHumanSize(s.Floats['downloadedBytes']));
-      Items[idx, 1]:=UTF8Decode(GetHumanSize(s.Floats['uploadedBytes']));
-      Items[idx, 2]:=s.Integers['filesAdded'];
-      Items[idx, 3]:=UTF8Decode(SecondsToString(s.Integers['secondsActive']));
+      Items[idx, 0]:=UTF8Decode(GetHumanSize(values.DownloadedBytes));
+      Items[idx, 1]:=UTF8Decode(GetHumanSize(values.UploadedBytes));
+      Items[idx, 2]:=values.FilesAdded;
+      Items[idx, 3]:=UTF8Decode(SecondsToString(values.SecondsActive));
     end;
   end;
 
 begin
+  Result:=True;
   if RpcObj.RPCVersion < 4 then
     exit;
   if s = nil then begin
-    ClearDetailsInfo;
+    ClearStatistics;
+    DetailsUpdated;
+    Result:=False;
+    exit;
+  end;
+  if not _GetStats('current-stats', currentStats) or
+    not _GetStats('cumulative-stats', cumulativeStats) then begin
+    ClearStatistics;
+    DetailsUpdated;
+    Result:=False;
     exit;
   end;
   gStats.BeginUpdate;
   try
     gStats.Enabled:=True;
     gStats.Color:=clWindow;
-    _Fill(1, s.Objects['current-stats']);
-    _Fill(2, s.Objects['cumulative-stats']);
+    _Fill(1, currentStats);
+    _Fill(2, cumulativeStats);
   finally
     gStats.EndUpdate;
   end;
   DetailsUpdated;
 end;
 
-procedure TMainForm.CheckStatus(Fatal: boolean);
+procedure TMainForm.CheckStatus(Fatal: boolean; const AStatus: string);
 var
   s: string;
   i: integer;
 begin
   with MainForm do begin
-    s:=TranslateString(RpcObj.Status, True);
+    if AStatus = '' then begin
+      s:=TranslateString(RpcObj.Status, True);
+      if s <> '' then
+        RpcObj.Status:='';
+    end
+    else
+      s:=TranslateString(AStatus, True);
     if s <> '' then begin
-      RpcObj.Status:='';
       if Fatal then
         DoDisconnect;
       ForceAppNormal;

--- a/rpc.pas
+++ b/rpc.pas
@@ -36,7 +36,7 @@ interface
 
 uses
   Classes, SysUtils, Forms, httpsend, syncobjs, fpjson, jsonparser, ssl_openssl,
-  ZStream, jsonscanner;
+  ZStream, jsonscanner, Math;
 
 resourcestring
   sTransmissionAt = 'Transmission%s at %s:%s';
@@ -56,6 +56,8 @@ type
   TRpcThread = class(TThread)
   private
     ResultData: TJSONData;
+    StatsValid: boolean;
+    StatsErrorShown: boolean;
     FRpc: TRpc;
     FPiecesSkip: integer;
     FStaticInfoId: integer;
@@ -86,6 +88,8 @@ type
     procedure DoFillTrackersList;
     procedure DoFillStats;
     procedure DoFillSessionInfo;
+    procedure NotifyStatsError;
+    procedure StatsErrorHandler(Data: PtrInt);
     procedure NotifyCheckStatus;
     procedure CheckStatusHandler(Data: PtrInt);
     function IsTerminated: boolean;
@@ -148,7 +152,10 @@ type
     procedure Connect;
     procedure Disconnect;
 
-    function SendRequest(req: TJSONObject; ReturnArguments: boolean = True; ATimeOut: integer = -1): TJSONObject;
+    function SendRequest(req: TJSONObject; ReturnArguments: boolean = True;
+      ATimeOut: integer = -1): TJSONObject; overload;
+    function SendRequest(req: TJSONObject; ReturnArguments: boolean;
+      ATimeOut: integer; out AResponseError: string): TJSONObject; overload;
     function RequestInfo(TorrentId: integer; const Fields: array of const; const ExtraFields: array of string): TJSONObject;
     function RequestInfo(TorrentId: integer; const Fields: array of const): TJSONObject;
 
@@ -332,7 +339,12 @@ end;
 
 procedure TRpcThread.DoFillStats;
 begin
-  MainForm.FillStatistics(ResultData as TJSONObject);
+  if Terminated or (csDestroying in MainForm.ComponentState) then
+    exit;
+  if ResultData = nil then
+    StatsValid:=MainForm.FillStatistics(nil)
+  else
+    StatsValid:=MainForm.FillStatistics(ResultData as TJSONObject);
 end;
 
 procedure TRpcThread.DoFillSessionInfo;
@@ -344,6 +356,18 @@ procedure TRpcThread.NotifyCheckStatus;
 begin
   if not Terminated then
     Application.QueueAsyncCall(@CheckStatusHandler, 0);
+end;
+
+procedure TRpcThread.NotifyStatsError;
+begin
+  if not Terminated then
+    Application.QueueAsyncCall(@StatsErrorHandler, 0);
+end;
+
+procedure TRpcThread.StatsErrorHandler(Data: PtrInt);
+begin
+  if Terminated or (csDestroying in MainForm.ComponentState) then exit;
+  MainForm.CheckStatus(False, 'Invalid server response.');
 end;
 
 procedure TRpcThread.CheckStatusHandler(Data: PtrInt);
@@ -530,19 +554,36 @@ end;
 
 procedure TRpcThread.GetStats;
 var
-  req, args: TJSONObject;
+  req, response: TJSONObject;
+  idx: integer;
+  ResponseError: string;
 begin
   req:=TJSONObject.Create;
   try
     req.Add('method', 'session-stats');
-    args:=FRpc.SendRequest(req);
-    if args <> nil then
+    response:=FRpc.SendRequest(req, False, -1, ResponseError);
+    if (response <> nil) or (ResponseError <> '') then
     try
-      ResultData:=args;
-      if not Terminated then
+      StatsValid:=response <> nil;
+      if StatsValid then begin
+        idx:=response.IndexOfName('arguments');
+        StatsValid:=idx >= 0;
+        if StatsValid then
+          StatsValid:=response.Items[idx] is TJSONObject;
+      end;
+      if not Terminated then begin
+        if StatsValid then
+          ResultData:=response.Items[idx]
+        else
+          ResultData:=nil;
         Synchronize(@DoFillStats);
+        if not StatsValid and not StatsErrorShown then begin
+          StatsErrorShown:=True;
+          NotifyStatsError;
+        end;
+      end;
     finally
-      args.Free;
+      response.Free;
     end;
   finally
     req.Free;
@@ -803,13 +844,21 @@ var
   decomp : TGzipDecompressionStream;
 begin
   decomp:=TGzipDecompressionStream.create(source);
-  Result:=TMemoryStream.create;
-  repeat
-    numRead:=decomp.read(buf,sizeof(buf));
-    Result.Write(buf,numRead);
-  until numRead < sizeof(buf);
-  Result.Position:=0;
-  decomp.Free;
+  try
+    Result:=TMemoryStream.create;
+    try
+      repeat
+        numRead:=decomp.read(buf,sizeof(buf));
+        Result.Write(buf,numRead);
+      until numRead < sizeof(buf);
+      Result.Position:=0;
+    except
+      FreeAndNil(Result);
+      raise;
+    end;
+  finally
+    decomp.Free;
+  end;
 end;
 
 function CreateJsonParser(serverResp : THTTPSend): TJSONParser;
@@ -819,8 +868,11 @@ begin
   begin
     { need to fully decompress as the parser relies on a working Seek() }
     decompressed:=DecompressGzipContent(serverResp.Document);
-    Result:=TJSONParser.Create(decompressed, [joUTF8]);
-    decompressed.Free;
+    try
+      Result:=TJSONParser.Create(decompressed, [joUTF8]);
+    finally
+      decompressed.Free;
+    end;
   end
   else
   begin
@@ -828,7 +880,18 @@ begin
   end;
 end;
 
-function TRpc.SendRequest(req: TJSONObject; ReturnArguments: boolean; ATimeOut: integer): TJSONObject;
+function TRpc.SendRequest(req: TJSONObject; ReturnArguments: boolean;
+  ATimeOut: integer): TJSONObject;
+var
+  ResponseError: string;
+begin
+  Result:=SendRequest(req, ReturnArguments, ATimeOut, ResponseError);
+  if ResponseError <> '' then
+    Status:=ResponseError;
+end;
+
+function TRpc.SendRequest(req: TJSONObject; ReturnArguments: boolean;
+  ATimeOut: integer; out AResponseError: string): TJSONObject;
 
   procedure StripHtmlTags(var AText: string);
   var
@@ -853,6 +916,13 @@ function TRpc.SendRequest(req: TJSONObject; ReturnArguments: boolean; ATimeOut: 
     SetLength(AText, WritePos - 1);
   end;
 
+  procedure SetResponseError(const AMessage: string);
+  begin
+    AResponseError:=AMessage;
+    if AResponseError = '' then
+      AResponseError:='Invalid server response.';
+  end;
+
 var
   obj: TJSONData;
   res: TJSONObject;
@@ -861,6 +931,7 @@ var
   i, j, OldTimeOut, OldDataTimeOut, OldNonblockSendTimeOut, RetryCnt: integer;
   locked, r: boolean;
 begin
+  AResponseError:='';
   if FRpcPath = '' then
     FRpcPath:=DefaultRpcPath;
   Status:='';
@@ -975,30 +1046,48 @@ begin
           break;
         end;
         Http.Document.Position:=0;
-        jp:=CreateJsonParser(Http);
-        { Clear under HttpLock before another request can reuse the shared HTTP
-          document buffer; the parser has read all response data it needs. }
-        Http.Document.Clear;
-        HttpLock.Leave;
-        locked:=False;
-        RequestStartTime:=0;
+        obj:=nil;
+        jp:=nil;
         try
           try
+            ClearExceptions(False);
+            jp:=CreateJsonParser(Http);
+            { Clear under HttpLock before another request can reuse the shared
+              HTTP document buffer; the parser has read all response data it
+              needs. }
+            Http.Document.Clear;
+            HttpLock.Leave;
+            locked:=False;
+            RequestStartTime:=0;
             obj:=jp.Parse;
+            { Surface delayed floating-point errors from JSON number parsing
+              while they can still be reported as an RPC error. }
+            ClearExceptions;
           finally
             jp.Free;
           end;
         except
           on E: Exception do
             begin
-              Status:=e.Message;
+              FreeAndNil(obj);
+              ClearExceptions(False);
+              SetResponseError(e.Message);
               break;
             end;
         end;
         try
           if obj is TJSONObject then begin
             res:=obj as TJSONObject;
-            s:=res.Strings['result'];
+            j:=res.IndexOfName('result');
+            if j < 0 then begin
+              SetResponseError('Invalid server response.');
+              break;
+            end;
+            if res.Items[j].JSONType <> jtString then begin
+              SetResponseError('Invalid server response.');
+              break;
+            end;
+            s:=res.Items[j].AsString;
             if AnsiCompareText(s, 'success') <> 0 then begin
               if Trim(s) = '' then
                 s:='Unknown error.';
@@ -1006,12 +1095,15 @@ begin
             end
             else begin
               if ReturnArguments then begin
-                Result:=res.Objects['arguments'];
-                if Result = nil then
-                  Status:='Arguments object not found.'
+                j:=res.IndexOfName('arguments');
+                if j < 0 then
+                  SetResponseError('Arguments object not found.')
+                else if not (res.Items[j] is TJSONObject) then
+                  SetResponseError('Arguments object not found.')
                 else begin
+                  Result:=res.Items[j] as TJSONObject;
 //                res.Extract(Result); // lazarus 1.2.6 ok
-                  res.Extract(res.IndexOf(Result)); // fix Tample :) lazarus 1.4.0 and high!
+                  res.Extract(j); // fix Tample :) lazarus 1.4.0 and high!
                   FreeAndNil(obj);
                 end;
               end
@@ -1023,7 +1115,7 @@ begin
             break;
           end
           else begin
-            Status:='Invalid server response.';
+            SetResponseError('Invalid server response.');
             break;
           end;
         finally


### PR DESCRIPTION
### **User description**
## Motivation

Malformed or incomplete `session-stats` responses can raise exceptions while
the Statistics tab is updated. In the synchronized RPC refresh path, those
exceptions can unwind the refresh thread and disconnect the client without
being handled as a normal RPC response error.

## Changes

- Require `arguments`, `current-stats`, and `cumulative-stats` to exist as
  JSON objects.
- Validate and convert every displayed field before updating any grid cell.
  Byte counters must be finite and non-negative; integer counters must also
  be integral and fit the UI's integer range.
- Clear only the Statistics grid when validation fails, then report the
  malformed response through the existing RPC status path.
- Surface delayed floating-point failures from JSON number parsing while the
  response is still inside the RPC error handler, and release any parsed JSON
  object on that path.

## Testing

- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default`
- Targeted validation harness covering valid data, missing objects and fields,
  wrong types, fractional and negative counters, integer overflow, and huge
  JSON integers and exponents
- `git diff --check`

Manual UI testing was not performed.


___

### **PR Type**
Bug fix


___

### **Description**
- Validate malformed `session-stats` responses before UI updates

- Clear invalid statistics without disconnecting RPC refreshes

- Safely report parser and response-format errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Response["RPC session-stats response"]
  Validation["Validate response and statistics fields"]
  Statistics["Update Statistics grid"]
  Error["Clear grid and show nonfatal error"]
  Response -- "contains valid data" --> Validation
  Validation -- "valid" --> Statistics
  Validation -- "invalid" --> Error
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Validate and safely clear Statistics tab data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Add reusable <code>ClearStatistics</code> grid-reset helper<br> <li> Validate all statistics values before grid updates<br> <li> Reject missing, malformed, negative, or overflowing counters<br> <li> Allow <code>CheckStatus</code> to display explicit nonfatal errors</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1565/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+123/-29</a></td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc.pas</strong><dd><code>Harden RPC response and statistics error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc.pas

<ul><li>Validate RPC envelopes and <code>arguments</code> object types<br> <li> Report malformed statistics responses asynchronously without <br>disconnecting<br> <li> Catch delayed JSON numeric parsing failures safely<br> <li> Ensure gzip streams and failed parse objects are released</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1565/files#diff-2ed877f1eb0cc61eeb41c8377461565d3043af70aaf9ac97b3a78679d020fa76">+125/-33</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics validation to prevent invalid or incomplete data from appearing.
  * Statistics now clear and become unavailable when data is invalid or the connection ends.
  * Improved handling of malformed or failed responses to prevent incorrect status updates.
* **Reliability**
  * Improved cleanup and error handling during communication failures and application shutdown.
  * Added clearer status reporting for connection and response errors.
  * Improved safeguards when updating statistics during shutdown or disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->