### PR TITLE
Fix Windows installers to record the correct application version

### DIFF
--- a/setup/win/setup.iss
+++ b/setup/win/setup.iss
@@ -1,6 +1,10 @@
+; Keep a three-part version for Windows uninstall metadata.
+; The AppVersion macro remains shortened for setup names and filenames.
+#define AppDisplayVersion GetFileVersion(SourcePath+'..\..\transgui.exe')
+#define AppDisplayVersion Copy(AppDisplayVersion, 1, RPos('.', AppDisplayVersion) - 1)
+
 #ifndef AppVersion
-  #define AppVersion GetFileVersion(SourcePath+'..\..\transgui.exe')
-  #define AppVersion Copy(AppVersion, 1, RPos('.', AppVersion) - 1)
+  #define AppVersion AppDisplayVersion
   #define tmpvar Copy(AppVersion, RPos('.', AppVersion) + 1, 3)
   #if tmpvar == "0"
     #define AppVersion Copy(AppVersion, 1, RPos('.', AppVersion) - 1)
@@ -53,6 +57,7 @@ Name: "zh_cn"; MessagesFile: "..\..\Inno Setup lang\ChineseSimplified.isl"
 [Setup]
 AppId=transgui
 AppName={#AppName}
+AppVersion={#AppDisplayVersion}
 AppVerName={#AppVerName}
 AppCopyright=Copyright (c) 2008-{#CurYear} by Yury Sidorov & Transmission Remote GUI working group
 AppPublisher={#AppPublisher}

--- a/setup/win_amd64/setup.iss
+++ b/setup/win_amd64/setup.iss
@@ -1,6 +1,10 @@
+; Keep a three-part version for Windows uninstall metadata.
+; The AppVersion macro remains shortened for setup names and filenames.
+#define AppDisplayVersion GetFileVersion(SourcePath+'..\..\transgui.exe')
+#define AppDisplayVersion Copy(AppDisplayVersion, 1, RPos('.', AppDisplayVersion) - 1)
+
 #ifndef AppVersion
-  #define AppVersion GetFileVersion(SourcePath+'..\..\transgui.exe')
-  #define AppVersion Copy(AppVersion, 1, RPos('.', AppVersion) - 1)
+  #define AppVersion AppDisplayVersion
   #define tmpvar Copy(AppVersion, RPos('.', AppVersion) + 1, 3)
   #if tmpvar == "0"
     #define AppVersion Copy(AppVersion, 1, RPos('.', AppVersion) - 1)
@@ -53,6 +57,7 @@ Name: "zh_cn"; MessagesFile: "..\..\Inno Setup lang\ChineseSimplified.isl"
 [Setup]
 AppId=transgui
 AppName={#AppName}
+AppVersion={#AppDisplayVersion}
 AppVerName={#AppVerName}
 AppCopyright=Copyright (c) 2008-{#CurYear} by Yury Sidorov & Transmission Remote GUI working group
 AppPublisher={#AppPublisher}


### PR DESCRIPTION
## Summary

Set Inno Setup's `AppVersion` in both Windows installer scripts so
their uninstall entries record `DisplayVersion=5.18.0`.

Keep the existing shortened `5.18` value for `AppVerName` and installer
filenames.

## Why

Without `DisplayVersion`, winget cannot reliably recognize the installed
release and may continue offering the same version as an upgrade.

The executable has the four-part Windows file version `5.18.0.0`.
Removing only the final component produces the canonical application
version `5.18.0`.

## Validation

- verified the version transformation produces `5.18.0`
- verified both installer variants use `AppDisplayVersion`
- verified the shortened `AppVersion` macro derives from `AppDisplayVersion`
- preserved CRLF line endings in both `.iss` files

Closes #1392.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer version information now displays a shortened, user-friendly version number.
  * Installer metadata consistently reflects the application’s displayed version across Windows packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->