### PR TITLE
Preserve invalid handles in UTF-8 INI streams

### DIFF
--- a/utils.pas
+++ b/utils.pas
@@ -306,7 +306,9 @@ end;
 
 destructor TFileStreamUTF8.Destroy;
 begin
-  FileClose(Handle);
+  if Handle <> feInvalidHandle then
+    FileClose(Handle);
+  inherited Destroy;
 end;
 
 { TIniFileUtf8 }
@@ -323,7 +325,7 @@ begin
   FStream:=TFileStreamUTF8.Create(AFileName, m);
   inherited Create(FStream, AEscapeLineFeeds);
   FileClose(FStream.Handle);
-  THandle(pointer(@FStream.Handle)^):=0;
+  THandle(pointer(@FStream.Handle)^):=feInvalidHandle;
 end;
 
 destructor TIniFileUtf8.Destroy;
@@ -340,7 +342,7 @@ begin
     h:=FileOpenUTF8(FFileName, fmOpenWrite or fmShareDenyWrite)
   else
     h:=FileCreateUTF8(FFileName);
-  if h = THandle(-1) then
+  if h = feInvalidHandle then
     raise Exception.Create('Unable to write to INI file.' + LineEnding + SysErrorMessageUTF8(GetLastOSError));
   THandle(pointer(@FStream.Handle)^):=h;
   try
@@ -348,7 +350,7 @@ begin
     FStream.Size:=FStream.Position;
   finally
     FileClose(FStream.Handle);
-    THandle(pointer(@FStream.Handle)^):=0;
+    THandle(pointer(@FStream.Handle)^):=feInvalidHandle;
   end;
 end;
 


### PR DESCRIPTION
## Summary

- detach closed INI backing streams with `feInvalidHandle` instead of zero
- avoid closing an already-detached handle in `TFileStreamUTF8.Destroy`
- use the same invalid-handle sentinel when checking update failures

## Why

Descriptor zero is valid on Unix. After `TIniFileUtf8` closed its backing file, it stored zero in `THandleStream.Handle`; the stream destructor could later close stdin or an unrelated resource that had reused descriptor zero.

## Validation

- exercised the descriptor-zero regression model with a reused descriptor
- verified detached streams retain `feInvalidHandle` after construction and updates
- verified the destructor calls the inherited destructor and closes only valid handles
- verified the branch is one commit ahead of `master` and changes only `utils.pas`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handle detachment for UTF-8 INI streams by using feInvalidHandle instead of 0. Prevents accidental closing of descriptor 0 (stdin) on Unix after INI files are closed.

- **Bug Fixes**
  - Use feInvalidHandle to detach the stream handle instead of 0.
  - Guard TFileStreamUTF8.Destroy to close only valid handles, then call inherited Destroy.
  - In UpdateFile, treat feInvalidHandle as the open-failure sentinel and restore it after closing.

<sup>Written for commit 526b8c1aa2c5cfb28475a5f01f78fd436b75ca0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handling to avoid attempting to close invalid file handles.
  * Enhanced temporary file handle management during file updates for greater stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->