### PR TITLE
Harden torrent-info RPC response handling

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -4613,17 +4613,25 @@ begin
     AppBusy;
     try
       res:=RpcObj.RequestInfo(gTorrents.Items[idxTorrentId, gTorrents.Row], ['downloadDir']);
-      if res = nil then
+      if res = nil then begin
         CheckStatus(False);
-      with res.Arrays['torrents'].Objects[0] do
-        n:=IncludeProperTrailingPathDelimiter(UTF8Encode(Strings['downloadDir'])) + UTF8Encode(widestring(gTorrents.Items[idxName, gTorrents.Row]));
-      s:=MapRemoteToLocal(n);
-      if s = '' then
-        s:=n;
-      if FileExistsUTF8(s) or DirectoryExistsUTF8(s) then begin
-        // File/folder exists - open it
-        OpenCurrentTorrent(False);
         exit;
+      end;
+      try
+        if res.Arrays['torrents'].Count = 0 then
+          exit;
+        with res.Arrays['torrents'].Objects[0] do
+          n:=IncludeProperTrailingPathDelimiter(UTF8Encode(Strings['downloadDir'])) + UTF8Encode(widestring(gTorrents.Items[idxName, gTorrents.Row]));
+        s:=MapRemoteToLocal(n);
+        if s = '' then
+          s:=n;
+        if FileExistsUTF8(s) or DirectoryExistsUTF8(s) then begin
+          // File/folder exists - open it
+          OpenCurrentTorrent(False);
+          exit;
+        end;
+      finally
+        res.Free;
       end;
     finally
       AppNormal;

--- a/rpc.pas
+++ b/rpc.pas
@@ -1143,10 +1143,11 @@ function TRpc.RequestInfo(TorrentId: integer; const Fields: array of const; cons
 var
   req, args: TJSONObject;
   _fields: TJSONArray;
-  i: integer;
+  i, RequestRpcVersion: integer;
   sl: TStringList;
 begin
   Result:=nil;
+  RequestRpcVersion:=FRPCVersion;
   req:=TJSONObject.Create;
   sl:=TStringList.Create;
   try
@@ -1161,7 +1162,7 @@ begin
     sl.AddStrings(ExtraFields);
     sl.Sort;
 
-    DeleteIfRpcLessThan(sl, 'labels', FRPCVersion, 16);
+    DeleteIfRpcLessThan(sl, 'labels', RequestRpcVersion, 16);
 
     for i:=sl.Count-2 downto 0 do
       if (sl[i]=sl[i+1]) then
@@ -1169,14 +1170,13 @@ begin
     for i:=0 to sl.Count-1 do
       _fields.Add(sl[i]);
     args.Add('fields', _fields);
-    if FRPCVersion >= 16 then
+    if RequestRpcVersion >= 16 then
       args.Add('format', 'table');
 
     req.Add('arguments', args);
-    if FRPCVersion >= 16 then
-      Result:=TranslateTableToObjects(SendRequest(req))
-    else
-      Result:=SendRequest(req);
+    Result:=SendRequest(req);
+    if (RequestRpcVersion >= 16) and (Result <> nil) then
+      Result:=TranslateTableToObjects(Result);
   finally
     sl.Free;
     req.Free;


### PR DESCRIPTION
### **User description**
## Summary

- capture one RPC-version snapshot per `RequestInfo` call
- use the same snapshot for field filtering, request formatting, and response decoding
- convert RPC 16+ table responses only after `SendRequest` succeeds
- stop the completed-torrent double-click path when torrent information is unavailable or empty
- release every non-nil torrent-info response after the double-click path finishes using it

## Why

`SendRequest` returns `nil` for transport, HTTP, JSON parsing, and RPC failures. The RPC 16+ path previously passed that result directly to `TranslateTableToObjects`, which dereferenced a nil response before the existing error path could handle it.

The completed-torrent double-click path also assumed that every non-nil response contained at least one torrent and retained the response object after use. If the selected torrent disappeared while the request was in flight, indexing `torrents[0]` could fail. Successful requests also left the returned object allocated.

## Implementation

- snapshot `FRPCVersion` once at the start of `RequestInfo`
- use the snapshot consistently for `labels` filtering, `format=table`, and table-response conversion
- call `SendRequest` exactly once and preserve `nil` on failure
- skip table conversion unless a successful RPC 16+ response exists
- exit before indexing an empty `torrents` array
- wrap all non-nil response handling in `try..finally` and free the response exactly once
- preserve existing status reporting, path mapping, file/folder opening, and outer `AppNormal` cleanup

## Validation

- verified failed requests retain `nil` and bypass table conversion
- verified successful RPC 16+ responses retain table conversion
- verified request formatting and response decoding use one version snapshot
- verified failed and empty double-click lookups exit before dereferencing response data
- verified all non-nil double-click response paths reach `res.Free`, including early exits
- ran `git diff --check`
- completed a full Lazarus rebuild successfully
- rebased onto the latest `master` as one commit changing only `main.pas` and `rpc.pas`


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent nil RPC table-response conversion failures

- Safely handle missing torrent lookup results

- Free completed-torrent RPC responses reliably

- Keep request version decisions consistent


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Version["RPC version snapshot"]
  Request["Torrent info request"]
  Response["Successful RPC response"]
  Table["Table-to-object conversion"]
  Open["Safe completed-torrent opening"]
  Version -- "formats request consistently" --> Request
  Request -- "returns non-nil result" --> Response
  Response -- "RPC 16+ only" --> Table
  Table -- "validates torrent data" --> Open
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Safely handle completed torrent info lookups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Exit after failed torrent-info requests while retaining status checks.<br> <li> Guard against empty <code>torrents</code> arrays before indexing the first item.<br> <li> Free successful RPC response objects in a <code>try..finally</code> block.<br> <li> Preserve existing path mapping and file-opening behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1569/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+17/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rpc.pas</strong><dd><code>Guard table RPC response conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rpc.pas

<ul><li>Snapshot <code>FRPCVersion</code> once per <code>RequestInfo</code> call.<br> <li> Use the snapshot for field filtering and table request formatting.<br> <li> Convert table responses only when <code>SendRequest</code> returns a result.<br> <li> Preserve <code>nil</code> responses for existing failure handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1569/files#diff-2ed877f1eb0cc61eeb41c8377461565d3043af70aaf9ac97b3a78679d020fa76">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older RPC versions by removing unsupported fields and applying version-appropriate response formatting.
  * Fixed handling of table responses when no data is returned.
  * Prevented errors when double-clicking torrents with missing or empty details.
  * Ensured torrent information is properly cleaned up after use.
  * Improved fallback behavior to open torrent properties when files or folders cannot be opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->