### PR TITLE
Use a portable invalid file handle in startup checks

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1291,7 +1291,7 @@ begin
   // Check for outdated IPC file
   if FileExistsUTF8(FIPCFileName) then begin
     h:=FileOpenUTF8(FIPCFileName, fmOpenRead or fmShareDenyNone);
-    if h <> INVALID_HANDLE_VALUE then begin
+    if h <> feInvalidHandle then begin
       i:=FileGetDate(h);
       FileClose(h);
       if (i > 0) and (Abs(Now - FileDateToDateTime(i)) > 1/MinsPerDay) then


### PR DESCRIPTION
### **User description**
## Summary

- replace the Windows-only `INVALID_HANDLE_VALUE` check in `CheckAppParams`
- compare `FileOpenUTF8` results with Free Pascal's `feInvalidHandle`
- keep stale IPC file cleanup behavior unchanged

## Why

The startup path is compiled for every platform, but it references a Windows API identifier. Lazarus 4 on Linux no longer exposes that identifier, causing compilation to fail before application code is built.

## Validation

- verified the changed check uses the same invalid-handle sentinel already used by the project's UTF-8 file helpers
- confirmed the branch changes only the stale IPC handle comparison in `main.pas`
- verified the branch is one commit ahead of `master`

Closes #1486.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the startup file-handle check portable by comparing `FileOpenUTF8` to `feInvalidHandle` instead of Windows `INVALID_HANDLE_VALUE`, restoring Lazarus 4 Linux builds and leaving stale IPC cleanup unchanged. Closes #1486.

<sup>Written for commit 88c466e288089b7753f8bd8d405bbb28a5c1daa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Restore Lazarus 4 Linux build compatibility

- Use Free Pascal’s portable invalid-handle sentinel

- Preserve stale IPC file cleanup behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FileOpen["FileOpenUTF8 result"]
  Sentinel["feInvalidHandle sentinel"]
  Cleanup["Stale IPC cleanup"]
  FileOpen -- "validate against" --> Sentinel
  Sentinel -- "allows valid handles to continue" --> Cleanup
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Use portable invalid file-handle sentinel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Replace Windows-only <code>INVALID_HANDLE_VALUE</code> with <code>feInvalidHandle</code>.<br> <li> Keep the <code>FileOpenUTF8</code> stale IPC-file validation flow unchanged.<br> <li> Allow cross-platform compilation with Lazarus 4 on Linux.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1570/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portability by correctly handling invalid file handles across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->