### PR TITLE
Prevent integer overflow when applying the FinishedQueue offset

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -6176,7 +6176,10 @@ begin
     if FieldExists[idxQueuePos] then begin
       j:=t.Integers['queuePosition'];
       if FTorrents[idxStatus, row] = TR_STATUS_FINISHED then
-        Inc(j, FinishedQueue);
+        if j > High(Integer) - FinishedQueue then
+          j:=High(Integer)
+        else
+          Inc(j, FinishedQueue);
       FTorrents[idxQueuePos, row]:=j;
     end;
 


### PR DESCRIPTION
### Motivation
- Fix a safety and reliability issue: adding `FinishedQueue = 1000000` to a daemon-provided `queuePosition` can exceed the `Integer` range. With overflow checking enabled, this can raise an exception; without it, the value can wrap around, interrupting automatic refreshes or causing incorrect sorting and display.

### Description
- Add a bounds check in `main.pas` where `t.Integers['queuePosition']` is processed. When `j > High(Integer) - FinishedQueue`, clamp `j` to `High(Integer)`; otherwise, call `Inc(j, FinishedQueue)`. This preserves the use of `FinishedQueue` as the sorting sentinel for finished items while preventing integer overflow.

### Testing
- Ran `git diff --check`; no whitespace or conflict-marker errors were found.
- Checked for installed compilers with `command -v fpc` and `command -v lazbuild`; neither command returned a path, indicating that Free Pascal and Lazarus are not installed in the environment.
- Ran `make DEBUG=1 all`; the build could not proceed because the Lazarus directory was not found, so a native project build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a735e6547bc83278ded3c65411551f1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds overflow protection when applying the `FinishedQueue` offset to `queuePosition`. This prevents exceptions or integer wraparound and keeps automatic refresh, sorting, and display behavior correct.

<sup>Written for commit ca2a3ba211e9c13d6c33b2205443e0e4d9999e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
