### PR TITLE
Read clipboard torrent links safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
           docker run -e DEBIAN_FRONTEND=noninteractive --rm -v "${PWD}:/transgui" "${{ matrix.image }}" bash -c '
             set -euo pipefail
             apt-get update -yqq
-            apt-get install -yqq --no-install-recommends libgtk2.0-0 twm xvfb xdotool
+            apt-get install -yqq --no-install-recommends libgtk2.0-0 twm xclip xvfb xdotool
             exec /transgui/setup/unix/smoke_test_gtk2_startup.sh /transgui/transgui
           '
 

--- a/main.pas
+++ b/main.pas
@@ -698,7 +698,9 @@ type
     FFlagsPath: string;
     FAddingTorrent: integer;
     FPendingTorrents: TStringList;
+    FPendingClipboardTorrents: TStringList;
     FLinksFromClipboard: boolean;
+    FCheckingClipboardLink: boolean;
     FLastClipboardLink: string;
     FLinuxOpenDoc: integer; // no del!
     FFromNow: boolean;
@@ -1182,6 +1184,39 @@ begin
     (Pos(#13, Value) > 0);
 end;
 
+function TryReadClipboardText(out ClipboardText: string): boolean;
+begin
+  Result:=False;
+  ClipboardText:='';
+  try
+    if not Clipboard.HasFormat(CF_Text) then
+      exit;
+    ClipboardText:=Clipboard.AsText;
+    Result:=True;
+  except
+    // Clipboard backends can fail transiently; skip this activation.
+  end;
+end;
+
+function TryNormalizeClipboardTorrentLink(const ClipboardText: string;
+  out TorrentLink: string): boolean;
+const
+  TorrentExt = '.torrent';
+begin
+  Result:=False;
+  TorrentLink:=Trim(ClipboardText);
+  if (TorrentLink = '') or HasIPCRecordDelimiter(TorrentLink) then
+    exit;
+  if IsHash(TorrentLink) then
+    TorrentLink:='magnet:?xt=urn:btih:' + TorrentLink;
+  if not IsProtocolSupported(TorrentLink) then
+    exit;
+  if not (AnsiStartsText('magnet:', TorrentLink) or
+          AnsiEndsText(TorrentExt, TorrentLink)) then
+    exit;
+  Result:=True;
+end;
+
 procedure AddTorrentFile(const FileName: string);
 var
   h: System.THandle;
@@ -1599,6 +1634,7 @@ begin
   lvTrackers.AlternateColor:=FAlterColor;
   gStats.AlternateColor:=FAlterColor;
   FPendingTorrents:=TStringList.Create;
+  FPendingClipboardTorrents:=TStringList.Create;
   FFilesCapt:=tabFiles.Caption;
   FPasswords:=TStringList.Create;
 {$ifdef LCLgtk2}
@@ -1762,7 +1798,7 @@ begin
 
   bidiMode := GetBiDi;
 
-  FLinksFromClipboard:=Ini.ReadBool('Interface', 'LinksFromClipboard', True);
+  FLinksFromClipboard:=Ini.ReadBool('Interface', 'LinksFromClipboard', False);
   Application.OnActivate:=@FormActivate;
   Application.OnException:=@ApplicationPropertiesException;
 
@@ -1914,6 +1950,7 @@ begin
   FTorrentProgress.Free;
   FPathMap.Free;
   FTorrents.Free;
+  FPendingClipboardTorrents.Free;
   FPendingTorrents.Free;
   try
     Ini.UpdateFile;
@@ -2241,7 +2278,7 @@ begin
 
     cbShowAddTorrentWindow.Checked:=Ini.ReadBool('Interface', 'ShowAddTorrentWindow', True);
     cbDeleteTorrentFile.Checked:=Ini.ReadBool('Interface', 'DeleteTorrentFile', False);
-    cbLinksFromClipboard.Checked:=Ini.ReadBool('Interface', 'LinksFromClipboard', True);
+    cbLinksFromClipboard.Checked:=Ini.ReadBool('Interface', 'LinksFromClipboard', False);
     edIntfScale.Value:=ReadIntfScale(IntfScale);
     cbCheckNewVersion.Checked:=Ini.ReadBool('Interface', 'CheckNewVersion', False);
     edCheckVersionDays.Value:=Ini.ReadInteger('Interface', 'CheckNewVersionDays', 5);
@@ -2274,6 +2311,8 @@ begin
       Ini.WriteBool('Interface', 'DeleteTorrentFile', cbDeleteTorrentFile.Checked);
       Ini.WriteBool('Interface', 'LinksFromClipboard', cbLinksFromClipboard.Checked);
       FLinksFromClipboard:=cbLinksFromClipboard.Checked;
+      if not FLinksFromClipboard then
+        FPendingClipboardTorrents.Clear;
 
       Ini.WriteInteger('Interface', 'Scaling', edIntfScale.Value);
 
@@ -3953,6 +3992,8 @@ end;
 
 procedure TMainForm.LocalWatchTimerTimer(Sender: TObject);
 begin
+  if FAddingTorrent <> 0 then
+    exit;
   ReadLocalFolderWatch;
   if FPendingTorrents.Count > 0 then
     begin
@@ -8111,6 +8152,13 @@ begin
   if FAddingTorrent <> 0 then
     exit;
 
+  if not FLinksFromClipboard then
+    FPendingClipboardTorrents.Clear
+  else if not FWatchDownloading and (FPendingClipboardTorrents.Count > 0) then begin
+    FPendingTorrents.AddStrings(FPendingClipboardTorrents);
+    FPendingClipboardTorrents.Clear;
+  end;
+
   Inc(FAddingTorrent);
   try
     if FPendingTorrents.Count > 0 then begin
@@ -8140,31 +8188,32 @@ begin
 end;
 
 procedure TMainForm.CheckClipboardLink;
-const
-  strTorrentExt = '.torrent';
 var
-  s: string;
+  ClipboardText, TorrentLink: string;
 begin
+  if not FLinksFromClipboard or FCheckingClipboardLink or
+    (csDestroying in ComponentState) or
+    (FPendingClipboardTorrents = nil) then
+      exit;
+  FCheckingClipboardLink:=True;
   try
-    if not FLinksFromClipboard then
-      exit;
-    s:=Clipboard.AsText;
-    if s = FLastClipboardLink then
-      exit;
-    FLastClipboardLink:=s;
-    if isHash(s) then s := 'magnet:?xt=urn:btih:' + s;
-    if not IsProtocolSupported(s) then
-      exit;
-    if (Pos('magnet:', LazUTF8.UTF8LowerCase(s)) <> 1) and (LazUTF8.UTF8LowerCase(Copy(s, Length(s) - Length(strTorrentExt) + 1, MaxInt)) <> strTorrentExt) then
-      exit;
-    if HasIPCRecordDelimiter(s) then
-      exit;
+    try
+      if not TryReadClipboardText(ClipboardText) then
+        exit;
+      if ClipboardText = FLastClipboardLink then
+        exit;
+      if not TryNormalizeClipboardTorrentLink(ClipboardText, TorrentLink) then begin
+        FLastClipboardLink:=ClipboardText;
+        exit;
+      end;
 
-    AddTorrentFile(s);
-    Clipboard.AsText:='';
-  except
-    // Turn off this function if an error occurs
-    FLinksFromClipboard:=False;
+      FPendingClipboardTorrents.Add(TorrentLink);
+      FLastClipboardLink:=ClipboardText;
+    except
+      // Clipboard monitoring is optional; retry on a later activation.
+    end;
+  finally
+    FCheckingClipboardLink:=False;
   end;
 end;
 

--- a/setup/unix/smoke_test_gtk2_startup.sh
+++ b/setup/unix/smoke_test_gtk2_startup.sh
@@ -25,11 +25,16 @@ runtime_home="$(mktemp -d)"
 startup_log="$runtime_home/startup.log"
 wm_log="$runtime_home/wm.log"
 xvfb_log="$runtime_home/xvfb.log"
+clipboard_log="$runtime_home/clipboard.log"
+clipboard_image="$runtime_home/clipboard.png"
 export HOME="$runtime_home"
 
 printf "%s\n" \
   "[MainForm]" \
   "FirstRun=0" \
+  "" \
+  "[Interface]" \
+  "LinksFromClipboard=1" \
   "" \
   "[Connection]" \
   "Host=127.0.0.1" \
@@ -40,6 +45,7 @@ printf "%s\n" "RandomPlacement" > "$runtime_home/.twmrc"
 
 xvfb_pid=""
 wm_pid=""
+clipboard_pid=""
 app_pid=""
 
 process_alive() {
@@ -96,6 +102,7 @@ cleanup() {
   trap - EXIT
   set +e
   stop_process "$app_pid" "transgui"
+  stop_process "$clipboard_pid" "xclip"
   stop_process "$wm_pid" "twm"
   stop_process "$xvfb_pid" "Xvfb"
   rm -rf "$runtime_home"
@@ -135,6 +142,19 @@ if ! process_alive "$wm_pid"; then
   exit 1
 fi
 
+base64 --decode > "$clipboard_image" << 'PNG'
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+PNG
+DISPLAY=:99 xclip -selection clipboard -target image/png -loops 0 \
+  -verbose "$clipboard_image" > "$clipboard_log" 2>&1 &
+clipboard_pid=$!
+sleep 0.5
+if ! process_alive "$clipboard_pid"; then
+  echo "xclip exited before transgui startup" >&2
+  cat "$clipboard_log" >&2
+  exit 1
+fi
+
 DISPLAY=:99 G_DEBUG=fatal-criticals LIBOVERLAY_SCROLLBAR=0 \
   "$transgui_binary" --home="$runtime_home" > "$startup_log" 2>&1 &
 app_pid=$!
@@ -169,6 +189,12 @@ fi
 sleep 4
 if ! process_alive "$app_pid"; then
   echo "transgui exited during startup" >&2
+  cat "$startup_log" >&2
+  exit 1
+fi
+if ! process_alive "$clipboard_pid"; then
+  echo "The image-only clipboard owner exited during startup" >&2
+  cat "$clipboard_log" >&2
   cat "$startup_log" >&2
   exit 1
 fi


### PR DESCRIPTION
### **User description**
### Motivation

Clipboard torrent monitoring was enabled by default and ran when the application became active. Besides being surprising for users who never opted in, the clipboard path could encounter non-text clipboard contents, lose clipboard data while clearing it, or mix clipboard additions with watched-folder processing.

### Changes

- Default `LinksFromClipboard` to `False` only when no preference has been saved; explicit existing preferences remain unchanged.
- Read the clipboard only when text is available and tolerate transient clipboard backend failures without disabling the feature.
- Normalize raw torrent hashes and accept only supported magnet or `.torrent` links after delimiter and protocol validation.
- Keep clipboard links in a separate pending queue and merge them only when watched-folder processing is inactive.
- Discard pending clipboard-derived links if clipboard monitoring is disabled before they are processed.
- Defer watched-folder scans while a torrent addition is active so re-entrant timer events cannot switch clipboard additions into watched-folder mode.
- Leave clipboard contents unchanged after queueing a torrent link.
- Extend the existing GTK2 startup smoke test with an image-only clipboard case and add `xclip` to that existing CI job. No new CI job is introduced.

### Testing

- `git diff --check`
- `shfmt` and `shellcheck`
- Linux builds across the existing CI architecture matrix
- macOS DMG build
- GTK2 startup smoke test with clipboard monitoring explicitly enabled and an image-only clipboard

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a735f5eaa9083278f70aa4f1a86bf5e)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Disable clipboard torrent monitoring by default.

- Safely validate and queue clipboard torrent links.

- Isolate clipboard additions from watched-folder batches.

- Smoke-test image-only GTK2 clipboard startup.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Clipboard["Clipboard text"] --> Validate["Validate supported torrent link"]
  Validate --> Queue["Queue clipboard torrent"]
  Queue --> Add["Add when watch processing is idle"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Harden clipboard torrent auto-add processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Default <code>LinksFromClipboard</code> to disabled when unset.<br> <li> Read clipboard text defensively and ignore transient failures.<br> <li> Normalize hashes and accept only magnet or <code>.torrent</code> links.<br> <li> Queue clipboard links separately and avoid re-entrant watch <br>processing.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1572/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+72/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smoke_test_gtk2_startup.sh</strong><dd><code>Cover image-only clipboard startup behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/unix/smoke_test_gtk2_startup.sh

<ul><li>Enable clipboard monitoring in the smoke-test profile.<br> <li> Create an image-only clipboard using <code>xclip</code>.<br> <li> Verify both application and clipboard owner survive startup.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1572/files#diff-bde644d171f6a97bcd4bdb23fad9e8cf719e1735d850456a3440395a98aedaa9">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Install clipboard tool for GTK2 smoke test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

- Install `xclip` for the GTK2 startup smoke test.


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1572/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard monitoring is now disabled by default.
  * Clipboard links are queued and transferred to torrent processing when appropriate.
  * Monitoring can recover from clipboard read failures without being disabled.

* **Bug Fixes**
  * Prevented duplicate or overlapping clipboard and local-folder processing.
  * Improved clipboard normalization, retry handling, and cleanup when monitoring is disabled.
  * Improved startup validation for clipboard handling on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->