### PR TITLE
Encapsulate UTF-8 INI stream handles

### DIFF
--- a/utils.pas
+++ b/utils.pas
@@ -51,6 +51,9 @@ type
   TFileStreamUTF8 = class(THandleStream)
   private
     FFileName: utf8string;
+    procedure SetHandleValue(AHandle: THandle);
+    procedure AttachFileHandle(AHandle: THandle);
+    procedure CloseFileHandle;
   public
     constructor Create(const AFileName: utf8string; Mode: Word);
     constructor Create(const AFileName: utf8string; Mode: Word; Rights: Cardinal);
@@ -304,10 +307,34 @@ begin
     inherited Create(lHandle);
 end;
 
+procedure TFileStreamUTF8.SetHandleValue(AHandle: THandle);
+begin
+  // THandleStream.Handle is read-only, but TIniFileUtf8 must reuse the
+  // stream instance retained by TIniFile when reopening the backing file.
+  THandle(pointer(@Handle)^):=AHandle;
+end;
+
+procedure TFileStreamUTF8.AttachFileHandle(AHandle: THandle);
+begin
+  if (Handle <> feInvalidHandle) or (AHandle = feInvalidHandle) then
+    raise EStreamError.Create('Invalid file handle state.');
+  SetHandleValue(AHandle);
+end;
+
+procedure TFileStreamUTF8.CloseFileHandle;
+var
+  h: THandle;
+begin
+  h:=Handle;
+  if h = feInvalidHandle then
+    exit;
+  SetHandleValue(feInvalidHandle);
+  FileClose(h);
+end;
+
 destructor TFileStreamUTF8.Destroy;
 begin
-  if Handle <> feInvalidHandle then
-    FileClose(Handle);
+  CloseFileHandle;
   inherited Destroy;
 end;
 
@@ -324,8 +351,7 @@ begin
     m:=fmCreate;
   FStream:=TFileStreamUTF8.Create(AFileName, m);
   inherited Create(FStream, AEscapeLineFeeds);
-  FileClose(FStream.Handle);
-  THandle(pointer(@FStream.Handle)^):=feInvalidHandle;
+  FStream.CloseFileHandle;
 end;
 
 destructor TIniFileUtf8.Destroy;
@@ -344,13 +370,16 @@ begin
     h:=FileCreateUTF8(FFileName);
   if h = feInvalidHandle then
     raise Exception.Create('Unable to write to INI file.' + LineEnding + SysErrorMessageUTF8(GetLastOSError));
-  THandle(pointer(@FStream.Handle)^):=h;
   try
+    FStream.AttachFileHandle(h);
+    h:=feInvalidHandle;
     inherited UpdateFile;
     FStream.Size:=FStream.Position;
   finally
-    FileClose(FStream.Handle);
-    THandle(pointer(@FStream.Handle)^):=feInvalidHandle;
+    if h <> feInvalidHandle then
+      FileClose(h)
+    else
+      FStream.CloseFileHandle;
   end;
 end;
 


### PR DESCRIPTION
### **User description**
## Summary

- centralize the existing low-level `THandleStream.Handle` mutation in `TFileStreamUTF8`
- add helpers for attaching and closing file handles with explicit ownership transfer
- stop `TIniFileUtf8` from directly reaching through the read-only `Handle` property
- preserve the existing open modes and post-write file truncation

## Why

PR #1568 fixed the invalid-handle sentinel, but `TIniFileUtf8` still changed its backing stream handle directly through `pointer(@FStream.Handle)^`. The stream instance must be reused because `TIniFile` retains it, so this follow-up keeps the existing behavior while making `TFileStreamUTF8` responsible for the handle lifecycle and ownership transitions.

`UpdateFile` now transfers ownership only after `AttachFileHandle` succeeds. If attachment fails, the newly opened local handle is closed. After a successful transfer, the stream-owned handle is detached and closed in the `finally` block.

This change intentionally centralizes rather than eliminates the implementation-dependent `Handle` mutation. Replacing that workaround entirely would require a broader change to how the retained `TIniFile` stream is backed and can be handled separately.

## Scope

- one commit
- only `utils.pas` is changed
- no dependency, build, packaging, or release changes

## Validation

Repository CI passed for the latest commit, including:

- Linux x86_64, i686, armv6l, and armv7l builds
- macOS DMG build
- Linux x86_64 GTK2 startup smoke test
- zip tarball smoke test
- static checks

Additional lifecycle validation performed while developing the change:

- 17 static ownership and scope invariants passed
- native descriptor lifecycle model passed under GCC and Clang
- the same model passed with AddressSanitizer, UndefinedBehaviorSanitizer, and leak detection
- 1,000 update cycles showed no file-descriptor growth
- normal GUI exit completed without a `close(0)` system call

The additional lifecycle checks are development-time validation rather than repository regression tests. The repository currently has no Windows CI job, so Windows is not covered by the PR's automated CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encapsulates UTF‑8 INI stream handle management in TFileStreamUTF8. Removes unsafe handle mutation in TIniFileUtf8 and makes ownership transfer explicit to prevent descriptor leaks.

- **Refactors**
  - Added SetHandleValue, AttachFileHandle, and CloseFileHandle to centralize handle changes and closure in TFileStreamUTF8; destructor now uses CloseFileHandle.
  - TIniFileUtf8 now uses attach/close helpers instead of writing to the read‑only Handle; UpdateFile transfers ownership only after a successful attach and closes the local handle on failure while preserving open modes and post‑write truncation.

<sup>Written for commit b233a53e23c2b2bdaff8b09cb209ae15ac276e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Encapsulate UTF-8 INI stream handle ownership.

- Safely attach, detach, and close backing handles.

- Preserve cleanup when stream attachment fails.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Opened["Opened INI file handle"]
  Stream["TFileStreamUTF8 ownership methods"]
  Update["TIniFileUtf8 update operation"]
  Closed["Detached and closed handle"]
  Opened -- "attaches to" --> Stream
  Stream -- "serves" --> Update
  Update -- "detaches through" --> Stream
  Stream -- "closes" --> Closed
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.pas</strong><dd><code>Encapsulate UTF-8 INI stream handle ownership</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils.pas

<ul><li>Add <code>TFileStreamUTF8</code> methods to set, attach, and close handles.<br> <li> Move read-only <code>Handle</code> property mutation into the stream class.<br> <li> Detach handles before closing them to prevent duplicate closure.<br> <li> Close locally opened handles if attachment cannot transfer ownership.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1574/files#diff-40ed7dc2f9c13ca965cb9f2993e5e3e807c8f2012e8df0573ccd2e8377495305">+36/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

