### PR TITLE
Fix high-resolution wheel delta handling in variable grids

### DIFF
--- a/vargrid.pas
+++ b/vargrid.pas
@@ -1181,12 +1181,9 @@ begin
     if WheelHorzSteps <> 0 then
     begin
       Dec(FHorzWheelAccumulator, WheelHorzSteps * 120);
-      {$IF LCL_FULLVERSION < 1080000}
       GridMouseWheel(Shift, -WheelHorzSteps);
-      {$ELSE}
-      GridMouseWheel(Shift, -WheelHorzSteps);
-      {$ENDIF}
     end;
+    Result := True;
   end
   else
   begin

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -96,7 +96,8 @@ type
     FOldOpt: TGridOptions;
     FNoDblClick: boolean;
     FStrEditor: TVarGridStringEditor;
-    FWheelAccumulator: Integer;
+    FVertWheelAccumulator: Integer;
+    FHorzWheelAccumulator: Integer;
 
     function GetRow: integer;
     function GetRowSelected(RowIndex: integer): boolean;
@@ -1162,29 +1163,54 @@ end;
 
 function TVarGrid.DoMouseWheel(Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint): Boolean;
 var
-  LinesToScroll: Integer;
+  WheelVertSteps, WheelHorzSteps: Integer;
 begin
   Result:=inherited DoMouseWheel(Shift, WheelDelta, MousePos);
-  if not Result then begin
-    Inc(FWheelAccumulator, WheelDelta);
-    LinesToScroll := FWheelAccumulator div 120;
-    if LinesToScroll <> 0 then
+  if Result then
+  begin
+    FVertWheelAccumulator := 0;
+    FHorzWheelAccumulator := 0;
+    Exit;
+  end;
+
+  if ssCtrl in Shift then
+  begin
+    Inc(FHorzWheelAccumulator, WheelDelta);
+    WheelHorzSteps := FHorzWheelAccumulator div 120;
+
+    if WheelHorzSteps <> 0 then
     begin
-      Dec(FWheelAccumulator, LinesToScroll * 120);
+      Dec(FHorzWheelAccumulator, WheelHorzSteps * 120);
+      {$IF LCL_FULLVERSION < 1080000}
+      GridMouseWheel(Shift, -WheelHorzSteps);
+      {$ELSE}
+      GridMouseWheel(Shift, -WheelHorzSteps);
+      {$ENDIF}
+    end;
+  end
+  else
+  begin
+    Inc(FVertWheelAccumulator, WheelDelta);
+    WheelVertSteps := FVertWheelAccumulator div 120;
+
+    if WheelVertSteps <> 0 then
+    begin
+      Dec(FVertWheelAccumulator, WheelVertSteps * 120);
+
       if Mouse.WheelScrollLines = -1 then
       begin
         {$IF LCL_FULLVERSION < 1080000}
-        GridMouseWheel(Shift, -LinesToScroll * VisibleRowCount);
+        GridMouseWheel(Shift, -WheelVertSteps * VisibleRowCount);
         {$ELSE}
-        GridMouseWheel(Shift, LinesToScroll * VisibleRowCount);
+        GridMouseWheel(Shift, WheelVertSteps * VisibleRowCount);
         {$ENDIF}
       end
       else
       begin
         {$IF LCL_FULLVERSION < 1080000}
-        GridMouseWheel(Shift, -LinesToScroll * Mouse.WheelScrollLines);
+        GridMouseWheel(Shift, -WheelVertSteps * Mouse.WheelScrollLines);
         {$ELSE}
-        GridMouseWheel(Shift, -LinesToScroll);
+        GridMouseWheel(Shift, -WheelVertSteps);
         {$ENDIF}
       end;
     end;
@@ -1196,7 +1222,8 @@ constructor TVarGrid.Create(AOwner: TComponent);
 begin
   FRow:=-1;
   FHintCell.x:=-1;
-  FWheelAccumulator:=0;
+  FVertWheelAccumulator := 0;
+  FHorzWheelAccumulator := 0;
   inherited Create(AOwner);
   FixedRows:=1;
   FixedCols:=0;

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -96,6 +96,7 @@ type
     FOldOpt: TGridOptions;
     FNoDblClick: boolean;
     FStrEditor: TVarGridStringEditor;
+    FWheelAccumulator: Integer;
 
     function GetRow: integer;
     function GetRowSelected(RowIndex: integer): boolean;
@@ -1160,21 +1161,34 @@ begin
 end;
 
 function TVarGrid.DoMouseWheel(Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint): Boolean;
+var
+  LinesToScroll: Integer;
 begin
   Result:=inherited DoMouseWheel(Shift, WheelDelta, MousePos);
   if not Result then begin
-    if Mouse.WheelScrollLines = -1 then
-  {$IF LCL_FULLVERSION < 1080000}
-      GridMouseWheel(Shift, -WheelDelta*VisibleRowCount div 120)
-    else
-      GridMouseWheel(Shift, -WheelDelta*Mouse.WheelScrollLines div 120);
-  {$ENDIF}
-  {$IF LCL_FULLVERSION >= 1080000}
-      GridMouseWheel(Shift, WheelDelta*VisibleRowCount div 120)
-    else
-      GridMouseWheel(Shift, -WheelDelta div 120);
-  {$ENDIF}
-      Result := True;
+    Inc(FWheelAccumulator, WheelDelta);
+    LinesToScroll := FWheelAccumulator div 120;
+    if LinesToScroll <> 0 then
+    begin
+      Dec(FWheelAccumulator, LinesToScroll * 120);
+      if Mouse.WheelScrollLines = -1 then
+      begin
+        {$IF LCL_FULLVERSION < 1080000}
+        GridMouseWheel(Shift, -LinesToScroll * VisibleRowCount);
+        {$ELSE}
+        GridMouseWheel(Shift, LinesToScroll * VisibleRowCount);
+        {$ENDIF}
+      end
+      else
+      begin
+        {$IF LCL_FULLVERSION < 1080000}
+        GridMouseWheel(Shift, -LinesToScroll * Mouse.WheelScrollLines);
+        {$ELSE}
+        GridMouseWheel(Shift, -LinesToScroll);
+        {$ENDIF}
+      end;
+    end;
+    Result := True;
   end;
 end;
 
@@ -1182,6 +1196,7 @@ constructor TVarGrid.Create(AOwner: TComponent);
 begin
   FRow:=-1;
   FHintCell.x:=-1;
+  FWheelAccumulator:=0;
   inherited Create(AOwner);
   FixedRows:=1;
   FixedCols:=0;


### PR DESCRIPTION
### **User description**
When using touchpad on a laptop, the scrolling doesn't work well, only moving upon large and fast movement.  
Thus changed the event catching to better represent the movement. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes laggy touchpad scrolling in `TVarGrid` by accumulating wheel deltas into 120-unit steps. Adds smooth Ctrl+wheel horizontal scrolling and prevents duplicate/default scrolling across LCL versions.

- Bug Fixes
  - Use FVertWheelAccumulator/FHorzWheelAccumulator to apply only full steps and carry remainders; reset both if the inherited handler consumes the event.
  - Map steps via Mouse.WheelScrollLines or VisibleRowCount with correct LCL sign; always return True to stop fallthrough; handle Ctrl+wheel as horizontal scrolling.

<sup>Written for commit 4597368f1b27ec317fca8391066149472d258d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Accumulate high-resolution touchpad wheel deltas

- Preserve fractional deltas until full scroll steps

- Add Ctrl+wheel horizontal grid scrolling

- Prevent duplicate default wheel handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wheel["Wheel delta input"]
  accumulators["Vertical or horizontal accumulator"]
  steps["Full 120-unit scroll steps"]
  grid["TVarGrid scrolling"]
  wheel -- "adds delta" --> accumulators
  accumulators -- "extracts steps" --> steps
  steps -- "scrolls grid" --> grid
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vargrid.pas</strong><dd><code>Improve variable grid wheel scrolling behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vargrid.pas

<ul><li>Add separate vertical and horizontal wheel-delta accumulators.<br> <li> Convert accumulated high-resolution deltas into 120-unit scroll steps.<br> <li> Preserve remaining partial deltas for subsequent touchpad events.<br> <li> Handle Ctrl+wheel horizontal scrolling and consume processed events.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1575/files#diff-d17225e70f5143a0f937451f414c996b51cc8a65f70225b4afaefb024dbfb64f">+52/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

