### PR TITLE
Fix out-of-bounds unit index in GetHumanSize

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1064,7 +1064,7 @@ begin
     Inc(i);
     sz:=sz/1024;
   end;
-  while i <= High(SizeNames) do begin
+  while i < High(SizeNames) do begin
     if sz < 1024 then
       break;
     sz:=sz/1024;


### PR DESCRIPTION
### Motivation

`GetHumanSize` can increment the unit index beyond the bounds of `SizeNames` when the input size is >= `1024^5`. When formatting daemon-controlled `leftUntilDone` values, this can cause an out-of-bounds array access, which can terminate the client or otherwise result in invalid behavior and a client-side denial of service.

### Description

- Change the loop condition in `GetHumanSize` from `while i <= High(SizeNames) do` to `while i < High(SizeNames) do`.
- Stop scaling at the largest supported unit while preserving the existing output format and rounding behavior.

### Testing

- Verified boundary behavior for `1024^5 - 1`, `1024^5`, infinity, and non-default `RoundTo` values.
- Confirmed that the resulting unit index remains within the valid `SizeNames` range.