### PR TITLE
Prevent out-of-bounds writes in GetTempate

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -1153,6 +1153,7 @@ begin
       exten:= Trim (tmp);
       tmp  := '';
     end;
+    if n > High(e) then break;
     e[n]:= exten;
     n   := n+1;
   end;


### PR DESCRIPTION
### Motivation

`GetTempate` in `addtorrent.pas` parses space-separated template entries into a fixed-size destination array without checking its bounds. Supplying more entries than the array can hold may cause an out-of-bounds write or a range-check exception.

### Description

- Check `High(e)` before writing to `e[n]`.
- Stop parsing when the destination array is full.
- Preserve the existing behavior for entries that fit within the array.

### Testing

- Verified that the bounds check occurs before the array write.
- Confirmed that oversized input stops parsing once the destination array is full.