### PR TITLE
Ensure folder history pruning terminates

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -924,6 +924,8 @@ var
   pFD : FolderData;
 begin
     max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
+    if max < 10 then
+      max:=10;
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max); // PETROV
 
     try
@@ -932,20 +934,23 @@ begin
         indx:=-1;
         for i:=0 to cbDestFolder.Items.Count - 1 do begin
           pFD := cbDestFolder.Items.Objects[i] as FolderData;
+          if pFD = nil then continue;
 
           fldr := DaysBetween(SysUtils.Date,pFD.Lst);
           if SysUtils.Date > pFD.Lst then
             fldr := 0- fldr;
 
           fldr := fldr + pFD.Hit;
-          if fldr < min then begin
+          if (indx < 0) or (fldr < min) then begin
             min := fldr;
             indx:= i;
           end;
         end;
 
         if indx > -1 then
-          cbDestFolder.Items.Delete(indx);
+          cbDestFolder.Items.Delete(indx)
+        else
+          break;
       end;
     except
       MessageDlg('Error: LS-001. Please contact the developer', mtError, [mbOK], 0);

--- a/main.pas
+++ b/main.pas
@@ -7872,10 +7872,12 @@ var
   pFD : FolderData;
 begin
     max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
+    if max < 10 then
+      max:=10;
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max);
 
     try
-    while (CB.Items.Count+maxdel) >= max do begin
+    while (CB.Items.Count+maxdel) > max do begin
       min := 9999999;
       indx:=-1;
       for i:=0 to CB.Items.Count - 1 do begin
@@ -7887,14 +7889,16 @@ begin
           fldr := 0- fldr;
 
         fldr := fldr + pFD.Hit;
-        if fldr < min then begin
+        if (indx < 0) or (fldr < min) then begin
           min := fldr;
           indx:= i;
         end;
       end;
 
       if indx > -1 then
-        CB.Items.Delete(indx);
+        CB.Items.Delete(indx)
+      else
+        break;
     end;
     except
       MessageDlg('Error: LS-010. Please contact the developer', mtError, [mbOK], 0);


### PR DESCRIPTION
### Motivation

Directory history pruning can fail to terminate when an imported or externally modified INI contains unsupported history settings or malformed folder metadata. A low `MaxFoldersHistory` value can keep the pruning condition true, while missing folder data or candidate scores outside the original sentinel range can leave an iteration without a removable entry.

`TMainForm.DeleteDirs` also used an inclusive pruning condition when reserving room for a new history entry. That caused a configured maximum of `N` entries to retain only `N-1` in normal paths.

### Description

- Clamp `MaxFoldersHistory` to the existing minimum of `10` in both `TMainForm.DeleteDirs` and `TAddTorrentForm.DeleteDirs`.
- Use a strict `>` pruning condition in `TMainForm.DeleteDirs`, matching `TAddTorrentForm.DeleteDirs` and allowing the configured maximum number of entries to be retained.
- Ignore folder entries without `FolderData` when selecting a pruning candidate.
- Select the first valid entry regardless of its score, removing reliance on the `9999999` sentinel as an implicit upper bound.
- Stop pruning when no removable entry can be selected, ensuring every pruning iteration either removes an entry or terminates.
- Keep the normalized history limit in the cached INI state for persistence through the existing `UpdateFile` paths.

### Testing

- Verified the boundary behavior for `maxdel = 0` and `maxdel = 1`: pruning now occurs only when the resulting history would exceed the configured maximum.
- Validated zero, negative, below-minimum, malformed-entry, and high-score pruning paths.
- Confirmed only `main.pas` and `addtorrent.pas` differ from the latest `master`.
- Completed a full Lazarus rebuild after applying the final changes.
- `git diff --check` passes.