### PR TITLE
Defer OpenSSL loading until HTTPS use

### DIFF
--- a/about.pas
+++ b/about.pas
@@ -83,7 +83,7 @@ procedure GoGitHub;
 
 implementation
 
-uses Main, utils, httpsend;
+uses Main, utils, httpsend, rpc;
 
 type
 
@@ -106,10 +106,18 @@ var
   CheckVersionThread: TCheckVersionThread;
 
 procedure CheckNewVersion(Async: boolean);
+var
+  SSLName, SSLUtilName: string;
 begin
   if CheckVersionThread <> nil then
     exit;
   Ini.WriteInteger('Interface', 'LastNewVersionCheck', Trunc(Now));
+  if not EnsureOpenSSLLoaded(SSLName, SSLUtilName) then begin
+    ForceAppNormal;
+    MessageDlg(SErrorCheckingVersion + LineEnding +
+      Format(sSSLLoadError, [SSLName, SSLUtilName]), mtError, [mbOK], 0);
+    exit;
+  end;
   CheckVersionThread:=TCheckVersionThread.Create(True);
   CheckVersionThread.FreeOnTerminate:=True;
   if Async then

--- a/download.pas
+++ b/download.pas
@@ -96,8 +96,14 @@ uses Main, rpc;
 
 function DownloadFile(const URL, DestFolder: string; const DestFileName, DisplayName: string): boolean;
 var
-  s: string;
+  s, SSLName, SSLUtilName: string;
 begin
+  if (CompareText(Copy(URL, 1, 6), 'https:') = 0) and
+     not EnsureOpenSSLLoaded(SSLName, SSLUtilName) then begin
+    MessageDlg(Format(sSSLLoadError, [SSLName, SSLUtilName]), mtError, [mbOK], 0);
+    Result:=False;
+    exit;
+  end;
   with TDownloadForm.Create(Application) do
   try
     s:=ExtractFileName(StringReplace(URL, '/', DirectorySeparator, [rfReplaceAll]));

--- a/main.pas
+++ b/main.pas
@@ -950,7 +950,7 @@ uses
   urllistenerosx,
 {$endif darwin}
   synacode, ConnOptions, clipbrd, DateUtils, TorrProps, DaemonOptions, About,
-  ToolWin, download, ColSetup, AddLink, MoveTorrent, ssl_openssl_lib, AddTracker, lcltype,
+  ToolWin, download, ColSetup, AddLink, MoveTorrent, AddTracker, lcltype,
   Options, ButtonPanel, BEncode, synautil, Math;
 
   {TMyHashMap}
@@ -1577,7 +1577,6 @@ begin
   txTorrentHeader.Font.Size:=txTransferHeader.Font.Size;
   TrayIcon.Icon.Assign(Application.Icon);
   RpcObj:=TRpc.Create;
-  RpcObj.InitSSL;
   FTorrents:=TVarList.Create(gTorrents.Columns.Count, 0);
   FTorrents.ExtraColumns:=TorrentsExtraColumns;
   gTorrents.Items.ExtraColumns:=TorrentsExtraColumns;
@@ -5165,7 +5164,7 @@ end;
 
 function TMainForm.DoConnect: boolean;
 var
-  Sec, pwd: string;
+  Sec, pwd, SSLName, SSLUtilName: string;
   i, j: integer;
 begin
   Result:=True;
@@ -5206,13 +5205,13 @@ begin
   RpcObj.Http.Sock.SSL.PFXfile:='';
   RpcObj.Http.Sock.SSL.KeyPassword:='';
   if Ini.ReadBool(Sec, 'UseSSL', False) then begin
-    RpcObj.InitSSL;
-    RpcObj.Http.Sock.SSL.PFXfile:=Ini.ReadString(Sec, 'CertFile', '');
-    RpcObj.Http.Sock.SSL.KeyPassword:=DecodeBase64(Ini.ReadString(Sec, 'CertPass', ''));
-    if not IsSSLloaded then begin
-      MessageDlg(Format(sSSLLoadError, [DLLSSLName, DLLUtilName]), mtError, [mbOK], 0);
+    if not RpcObj.InitSSL(SSLName, SSLUtilName) then begin
+      MessageDlg(Format(sSSLLoadError, [SSLName, SSLUtilName]), mtError, [mbOK], 0);
+      Result:=False;
       exit;
     end;
+    RpcObj.Http.Sock.SSL.PFXfile:=Ini.ReadString(Sec, 'CertFile', '');
+    RpcObj.Http.Sock.SSL.KeyPassword:=DecodeBase64(Ini.ReadString(Sec, 'CertPass', ''));
     RpcObj.Url:='https';
   end
   else

--- a/rpc.pas
+++ b/rpc.pas
@@ -140,7 +140,7 @@ type
 
     constructor Create;
     destructor Destroy; override;
-    procedure InitSSL;
+    function InitSSL(out ASSLName, AUtilName: string): boolean;
 
     procedure Lock;
     procedure Unlock;
@@ -164,9 +164,60 @@ type
 var
   RemotePathDelimiter: char = '/';
 
+function EnsureOpenSSLLoaded(out ASSLName, AUtilName: string): boolean;
+
 implementation
 
 uses Main, ssl_openssl_lib, synafpc, blcksock;
+
+var
+  OpenSSLInitLock: TCriticalSection;
+
+function EnsureOpenSSLLoaded(out ASSLName, AUtilName: string): boolean;
+{$ifdef unix}
+{$ifndef darwin}
+  procedure CheckOpenSSL;
+  const
+  OpenSSLVersions: array[1..6] of string =
+  ('3', '1.1', '1.1.0', '1.0.2', '1.0.0', '0.9.8');
+  var
+    hLib1, hLib2: TLibHandle;
+    i: integer;
+  begin
+    for i:=Low(OpenSSLVersions) to High(OpenSSLVersions) do begin
+      hlib1:=LoadLibrary(PChar('libssl.so.' + OpenSSLVersions[i]));
+      hlib2:=LoadLibrary(PChar('libcrypto.so.' + OpenSSLVersions[i]));
+      if hLib2 <> 0 then
+        FreeLibrary(hLib2);
+      if hLib1 <> 0 then
+        FreeLibrary(hLib1);
+      if (hLib1 <> 0) and (hLib2 <> 0) then begin
+        DLLSSLName:='libssl.so.' + OpenSSLVersions[i];
+        DLLUtilName:='libcrypto.so.' + OpenSSLVersions[i];
+        break;
+      end;
+    end;
+  end;
+{$endif darwin}
+{$endif unix}
+begin
+  OpenSSLInitLock.Enter;
+  try
+    if not IsSSLloaded then begin
+{$ifdef unix}
+{$ifndef darwin}
+      CheckOpenSSL;
+{$endif darwin}
+{$endif unix}
+      InitSSLInterface;
+    end;
+    Result:=IsSSLloaded;
+    ASSLName:=DLLSSLName;
+    AUtilName:=DLLUtilName;
+  finally
+    OpenSSLInitLock.Leave;
+  end;
+end;
 
 function TranslateTableToObjects(reply: TJSONObject) : TJSONObject;
 var
@@ -740,43 +791,9 @@ begin
   inherited Destroy;
 end;
 
-procedure TRpc.InitSSL;
-{$ifdef unix}
-{$ifndef darwin}
-  procedure CheckOpenSSL;
-  const
-  OpenSSLVersions: array[1..6] of string =
-  ('3', '1.1', '1.1.0', '1.0.2', '1.0.0', '0.9.8');
-  var
-    hLib1, hLib2: TLibHandle;
-    i: integer;
-  begin
-    for i:=Low(OpenSSLVersions) to High(OpenSSLVersions) do begin
-      hlib1:=LoadLibrary(PChar('libssl.so.' + OpenSSLVersions[i]));
-      hlib2:=LoadLibrary(PChar('libcrypto.so.' + OpenSSLVersions[i]));
-      if hLib2 <> 0 then
-        FreeLibrary(hLib2);
-      if hLib1 <> 0 then
-        FreeLibrary(hLib1);
-      if (hLib1 <> 0) and (hLib2 <> 0) then begin
-        DLLSSLName:='libssl.so.' + OpenSSLVersions[i];
-        DLLUtilName:='libcrypto.so.' + OpenSSLVersions[i];
-        break;
-      end;
-    end;
-  end;
-{$endif darwin}
-{$endif unix}
+function TRpc.InitSSL(out ASSLName, AUtilName: string): boolean;
 begin
-  if IsSSLloaded then exit;
-{$ifdef unix}
-{$ifndef darwin}
-  CheckOpenSSL;
-{$endif darwin}
-{$endif unix}
-  if InitSSLInterface then
-    SSLImplementation := TSSLOpenSSL;
-  CreateHttp;
+  Result:=EnsureOpenSSLLoaded(ASSLName, AUtilName);
 end;
 
 type TGzipDecompressionStream=class(TDecompressionStream)
@@ -1263,5 +1280,9 @@ begin
   RequestStartTime:=0;
   FRpcPath:='';
 end;
+
+initialization
+  // Keep this lock alive for the lifetime of the process.
+  OpenSSLInitLock:=TCriticalSection.Create;
 
 end.

--- a/synapse/source/lib/ssl_openssl.pas
+++ b/synapse/source/lib/ssl_openssl.pas
@@ -1026,7 +1026,6 @@ end;
 {==============================================================================}
 
 initialization
-  if InitSSLInterface then
-    SSLImplementation := TSSLOpenSSL;
+  SSLImplementation := TSSLOpenSSL;
 
 end.


### PR DESCRIPTION
### Motivation

Synapse previously loaded OpenSSL libraries during unit initialization, including for startup and plain HTTP sessions. On Windows this resolves unqualified OpenSSL DLL names before HTTPS functionality is needed.

This change defers library loading until the first HTTPS operation. It reduces eager startup exposure but does not eliminate the unqualified DLL search used when HTTPS is eventually requested.

### Changes

- Register the Synapse `TSSLOpenSSL` backend without loading OpenSSL libraries.
- Load OpenSSL on the main thread before HTTPS RPC connections, version checks, and downloads create or use their sockets.
- Preserve Linux versioned soname discovery and existing macOS and Windows library selection.
- Return consistent missing-library errors without rebuilding the shared RPC HTTP object.
- Keep startup, plain HTTP RPC connections, and plain HTTP downloads free of OpenSSL loading.

### Testing

- `lazbuild -B transgui.lpi`
- `git -c core.whitespace=cr-at-eol diff --check`
- Verified plain HTTP startup and RPC use do not map or attempt to load OpenSSL.
- Verified first HTTPS RPC use loads `libssl.so.3` and `libcrypto.so.3`.
- Verified missing OpenSSL libraries leave plain HTTP operation and shutdown functional.