### PR TITLE
Remove fixed limits from file template handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,33 @@ jobs:
             exit 1
           fi
 
+  pascal-unit-tests:
+    name: Test / Pascal unit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Run file template tests
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/transgui:ro" debian:bookworm bash -c '
+            set -euo pipefail
+            apt-get update -yqq
+            apt-get install -yqq --no-install-recommends fp-compiler fp-units-fcl
+            mkdir -p /tmp/transgui-tests/units /tmp/transgui-tests/bin
+            fpc -B \
+              -Fu/transgui \
+              -Fu/transgui/tests \
+              -FU/tmp/transgui-tests/units \
+              -FE/tmp/transgui-tests/bin \
+              /transgui/tests/run_filetemplates_tests.lpr
+            /tmp/transgui-tests/bin/run_filetemplates_tests --all
+          '
+
   zip-tarball-test:
     name: Test / Zip tarball smoke
     runs-on: ubuntu-latest
@@ -314,6 +341,7 @@ jobs:
     name: Release / GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - pascal-unit-tests
       - zip-tarball-test
       - linux-build
       - macos-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,34 @@ jobs:
             exit 1
           fi
 
+
+  pascal-unit-tests:
+    name: Test / Pascal unit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Run file template tests
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/transgui:ro" debian:bookworm bash -c '
+            set -euo pipefail
+            apt-get update -yqq
+            apt-get install -yqq --no-install-recommends fp-compiler fp-units-fcl
+            mkdir -p /tmp/transgui-tests/units /tmp/transgui-tests/bin
+            fpc -B \
+              -Fu/transgui \
+              -Fu/transgui/tests \
+              -FU/tmp/transgui-tests/units \
+              -FE/tmp/transgui-tests/bin \
+              /transgui/tests/run_filetemplates_tests.lpr
+            /tmp/transgui-tests/bin/run_filetemplates_tests --all
+          '
+
   zip-tarball-test:
     name: Test / Zip tarball smoke
     runs-on: ubuntu-latest
@@ -314,6 +342,7 @@ jobs:
     name: Release / GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - pascal-unit-tests
       - zip-tarball-test
       - linux-build
       - macos-build

--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -84,8 +84,6 @@ type
     procedure FormShow(Sender: TObject);
     procedure OKButtonClick(Sender: TObject);
     procedure SearchGoodExtension ();
-    function  GetTempate (ext:string; var e: array of string):integer;
-    function  IsFileTemplate(filename:string; cntE : integer; e: array of string):boolean;
     function  CorrectPath (path: string): string;
     procedure DeleteDirs(maxdel : Integer);
 
@@ -185,7 +183,7 @@ const
 
 implementation
 
-uses lclintf, lcltype, main, variants, Utils, rpc, lclproc;
+uses lclintf, lcltype, main, variants, Utils, rpc, lclproc, FileTemplates;
 
 const
   roChecked   = $030000;
@@ -1155,106 +1153,13 @@ begin
   UpdateSize;
 end;
 
-function  TAddTorrentForm.GetTempate (ext:string; var e: array of string):integer;
-var
-  tmp,exten : string;
-  i,n : integer;
-begin
-  tmp   := ext;
-  exten := ext;
-  n     := 0;
-  while tmp <> '' do begin
-    i := Pos (' ', tmp);
-    if (i <> 0) then begin
-      exten:= Trim (Copy (tmp, 1, i-1));
-      tmp  := Trim (Copy (tmp, i, 999));
-      end
-    else begin
-      exten:= Trim (tmp);
-      tmp  := '';
-    end;
-    if n > High(e) then break;
-    e[n]:= exten;
-    n   := n+1;
-  end;
-  GetTempate := n;
-end;
-
-function  TAddTorrentForm.IsFileTemplate(filename:string; cntE : integer; e: array of string):boolean;
-var
-  tmp, tmpExt, tmp_Name, sstr: string;
-  i,n,lstr,j,k, total_sstr, total_templ : integer;
-  ok : boolean;
-  re : boolean;
-begin
-  IsFileTemplate := false;
-
-  tmp := filename;
-  lstr:= Length(tmp);
-  for i:=1 to lstr-1 do begin
-    if (tmp[lstr-i]= '/') or (tmp[lstr-i]= '\') then begin
-      tmp := Copy (tmp, lstr-i+1, 999);
-      Break;
-    end;
-  end;
-
-  for i:=0 to cntE-1 do begin
-      tmpExt     := e[i];
-      tmp_Name   := tmp;
-      total_sstr := 0;
-      total_templ:= 0;
-      while tmpExt <> '' do begin
-        j := Pos ('*', tmpExt);
-        if j <> 0 then begin
-          sstr  := Copy (tmpExt, 1, j-1);
-          tmpExt:= Copy (tmpExt, j+1, 999);
-          re    := false;
-          end
-        else begin
-          sstr  := Trim (tmpExt);
-          tmpExt:= '';
-          re    := true;
-        end;
-        if sstr = '' then continue;
-
-        total_templ := total_templ +1;
-        n           := Length(sstr);
-        ok          := false;
-        while 1 = 1 do begin
-          if tmp_Name = '' then break;
-          k := Pos (sstr, tmp_Name);
-          if k <> 0 then begin
-            tmp_Name    := Copy (tmp_Name, k+n, 999);
-            if ((tmpExt ='') and (re=true)) and (tmp_Name <> '') then begin
-              continue;
-            end else begin
-              total_sstr := total_sstr +1;
-              ok         := true;
-              Break;
-            end;
-          end else begin
-            Break;
-          end;
-        end;
-        if ok = true then break;
-      end;
-
-      if total_sstr = total_templ then begin
-        IsFileTemplate := true;
-        Break;
-      end;
-  end;
-end;
-
-
 procedure TAddTorrentForm.SearchGoodExtension ();
 var
   i,j, jMax, torrMax : integer;
   s, filename : string;
   filesize, dTotal,dTotalMax : double;
   pFD : FolderData;
-  e : array [0..50] of string;
-  n : integer;
+  e : TFileTemplates;
 begin
     dTotalMax := 0;
     jMax      :=-1;
@@ -1265,7 +1170,7 @@ begin
         s    := Trim(pFD.Ext);
         if s = '' then continue;
 
-        n      := GetTempate (AnsiLowerCase(s), e);
+        e      := ParseFileTemplates(AnsiLowerCase(s));
         dTotal := 0;
         torrMax:= lvFiles.Items.Count;
         if torrMax > 100 then torrMax := 100;
@@ -1274,7 +1179,7 @@ begin
             if not FTree.IsFolder(i) then begin
               filename := lvFiles.Items[idxFileName, i];
               filesize := double(lvFiles.Items[idxFileSize, i]);
-              if IsFileTemplate(filename, n,e) = true then
+              if IsFileTemplate(filename, e) = true then
                 dTotal := dTotal + filesize;
             end;
         end;

--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -84,8 +84,7 @@ type
     procedure FormShow(Sender: TObject);
     procedure OKButtonClick(Sender: TObject);
     procedure SearchGoodExtension ();
-    function  GetTempate (ext:string; var e: array of string):integer;
-    function  IsFileTemplate(filename:string; cntE : integer; e: array of string):boolean;
+    function  IsFileTemplate(filename:string; const e: array of string):boolean;
     function  CorrectPath (path: string): string;
     procedure DeleteDirs(maxdel : Integer);
 
@@ -182,7 +181,7 @@ const
 
 implementation
 
-uses lclintf, lcltype, main, variants, Utils, rpc, lclproc;
+uses lclintf, lcltype, main, variants, Utils, rpc, lclproc, FileTemplates;
 
 const
   roChecked   = $030000;
@@ -1135,32 +1134,7 @@ begin
   UpdateSize;
 end;
 
-function  TAddTorrentForm.GetTempate (ext:string; var e: array of string):integer;
-var
-  tmp,exten : string;
-  i,n : integer;
-begin
-  tmp   := ext;
-  exten := ext;
-  n     := 0;
-  while tmp <> '' do begin
-    i := Pos (' ', tmp);
-    if (i <> 0) then begin
-      exten:= Trim (Copy (tmp, 1, i-1));
-      tmp  := Trim (Copy (tmp, i, 999));
-      end
-    else begin
-      exten:= Trim (tmp);
-      tmp  := '';
-    end;
-    if n > High(e) then break;
-    e[n]:= exten;
-    n   := n+1;
-  end;
-  GetTempate := n;
-end;
-
-function  TAddTorrentForm.IsFileTemplate(filename:string; cntE : integer; e: array of string):boolean;
+function  TAddTorrentForm.IsFileTemplate(filename:string; const e: array of string):boolean;
 var
   tmp, tmpExt, tmp_Name, sstr: string;
   i,n,lstr,j,k, total_sstr, total_templ : integer;
@@ -1178,7 +1152,7 @@ begin
     end;
   end;
 
-  for i:=0 to cntE-1 do begin
+  for i:=0 to High(e) do begin
       tmpExt     := e[i];
       tmp_Name   := tmp;
       total_sstr := 0;
@@ -1233,8 +1207,7 @@ var
   s, filename : string;
   filesize, dTotal,dTotalMax : double;
   pFD : FolderData;
-  e : array [0..50] of string;
-  n : integer;
+  e : TFileTemplates;
 begin
     dTotalMax := 0;
     jMax      :=-1;
@@ -1245,7 +1218,7 @@ begin
         s    := Trim(pFD.Ext);
         if s = '' then continue;
 
-        n      := GetTempate (AnsiLowerCase(s), e);
+        e      := ParseFileTemplates(AnsiLowerCase(s));
         dTotal := 0;
         torrMax:= lvFiles.Items.Count;
         if torrMax > 100 then torrMax := 100;
@@ -1254,7 +1227,7 @@ begin
             if not FTree.IsFolder(i) then begin
               filename := lvFiles.Items[idxFileName, i];
               filesize := double(lvFiles.Items[idxFileSize, i]);
-              if IsFileTemplate(filename, n,e) = true then
+              if IsFileTemplate(filename, e) = true then
                 dTotal := dTotal + filesize;
             end;
         end;

--- a/filetemplates.pas
+++ b/filetemplates.pas
@@ -1,0 +1,128 @@
+unit FileTemplates;
+
+{$mode objfpc}{$H+}
+
+interface
+
+type
+  TFileTemplates = array of string;
+
+function ParseFileTemplates(const Value: string): TFileTemplates;
+function IsFileTemplate(const FileName: string;
+  const Templates: array of string): boolean;
+
+implementation
+
+uses
+  SysUtils;
+
+function ParseFileTemplates(const Value: string): TFileTemplates;
+var
+  i, TokenCount, TokenStart, ValueLength: integer;
+  Token: string;
+begin
+  Result:=nil;
+  ValueLength:=Length(Value);
+  TokenCount:=0;
+  i:=1;
+  while i <= ValueLength do begin
+    while (i <= ValueLength) and (Value[i] = ' ') do
+      Inc(i);
+    if i > ValueLength then
+      break;
+    Inc(TokenCount);
+    while (i <= ValueLength) and (Value[i] <> ' ') do
+      Inc(i);
+  end;
+
+  SetLength(Result, TokenCount);
+  TokenCount:=0;
+  i:=1;
+  while i <= ValueLength do begin
+    while (i <= ValueLength) and (Value[i] = ' ') do
+      Inc(i);
+    if i > ValueLength then
+      break;
+    TokenStart:=i;
+    while (i <= ValueLength) and (Value[i] <> ' ') do
+      Inc(i);
+    Token:=Trim(Copy(Value, TokenStart, i - TokenStart));
+    if Token <> '' then begin
+      Result[TokenCount]:=Token;
+      Inc(TokenCount);
+    end;
+  end;
+  SetLength(Result, TokenCount);
+end;
+
+function IsFileTemplate(const FileName: string;
+  const Templates: array of string): boolean;
+var
+  tmp, tmpExt, tmp_Name, sstr: string;
+  i,n,lstr,j,k, total_sstr, total_templ : integer;
+  ok : boolean;
+  re : boolean;
+begin
+  Result:=false;
+
+  tmp:=FileName;
+  lstr:=Length(tmp);
+  for i:=1 to lstr-1 do begin
+    if (tmp[lstr-i]= '/') or (tmp[lstr-i]= '\') then begin
+      tmp:=Copy(tmp, lstr-i+1, Length(tmp));
+      Break;
+    end;
+  end;
+
+  for i:=0 to High(Templates) do begin
+    tmpExt:=Templates[i];
+    tmp_Name:=tmp;
+    total_sstr:=0;
+    total_templ:=0;
+    while tmpExt <> '' do begin
+      j:=Pos('*', tmpExt);
+      if j <> 0 then begin
+        sstr:=Copy(tmpExt, 1, j-1);
+        tmpExt:=Copy(tmpExt, j+1, Length(tmpExt));
+        re:=false;
+      end
+      else begin
+        sstr:=Trim(tmpExt);
+        tmpExt:='';
+        re:=true;
+      end;
+      if sstr = '' then
+        continue;
+
+      Inc(total_templ);
+      n:=Length(sstr);
+      ok:=false;
+      while true do begin
+        if tmp_Name = '' then
+          break;
+        k:=Pos(sstr, tmp_Name);
+        if k <> 0 then begin
+          tmp_Name:=Copy(tmp_Name, k+n, Length(tmp_Name));
+          if (tmpExt = '') and re and (tmp_Name <> '') then
+            continue
+          else begin
+            Inc(total_sstr);
+            ok:=true;
+            Break;
+          end;
+        end
+        else
+          Break;
+      end;
+      if ok then
+        Break;
+    end;
+
+    if total_sstr = total_templ then begin
+      Result:=true;
+      Break;
+    end;
+  end;
+end;
+
+end.

--- a/filetemplates.pas
+++ b/filetemplates.pas
@@ -1,0 +1,55 @@
+unit FileTemplates;
+
+{$mode objfpc}{$H+}
+
+interface
+
+type
+  TFileTemplates = array of string;
+
+function ParseFileTemplates(const Value: string): TFileTemplates;
+
+implementation
+
+uses
+  SysUtils;
+
+function ParseFileTemplates(const Value: string): TFileTemplates;
+var
+  i, TokenCount, TokenStart, ValueLength: integer;
+  Token: string;
+begin
+  ValueLength:=Length(Value);
+  TokenCount:=0;
+  i:=1;
+  while i <= ValueLength do begin
+    while (i <= ValueLength) and (Value[i] = ' ') do
+      Inc(i);
+    if i > ValueLength then
+      break;
+    Inc(TokenCount);
+    while (i <= ValueLength) and (Value[i] <> ' ') do
+      Inc(i);
+  end;
+
+  SetLength(Result, TokenCount);
+  TokenCount:=0;
+  i:=1;
+  while i <= ValueLength do begin
+    while (i <= ValueLength) and (Value[i] = ' ') do
+      Inc(i);
+    if i > ValueLength then
+      break;
+    TokenStart:=i;
+    while (i <= ValueLength) and (Value[i] <> ' ') do
+      Inc(i);
+    Token:=Trim(Copy(Value, TokenStart, i - TokenStart));
+    if Token <> '' then begin
+      Result[TokenCount]:=Token;
+      Inc(TokenCount);
+    end;
+  end;
+  SetLength(Result, TokenCount);
+end;
+
+end.

--- a/tests/filetemplates_tests.pas
+++ b/tests/filetemplates_tests.pas
@@ -1,0 +1,118 @@
+unit FileTemplates_Tests;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  SysUtils, fpcunit, testregistry, FileTemplates;
+
+type
+  TFileTemplatesTest = class(TTestCase)
+  private
+    procedure CheckTemplates(const Input: string; const Expected: array of string);
+    function BuildTemplates(Count: integer): string;
+  published
+    procedure ParsesEmptyInput;
+    procedure ParsesSingleTemplate;
+    procedure ParsesMultipleTemplates;
+    procedure IgnoresRepeatedSpaces;
+    procedure PreservesTemplateText;
+    procedure SplitsOnlyOnSpaces;
+    procedure TrimsControlWhitespaceAtTemplateBoundaries;
+    procedure ParsesBeyondLegacyCapacity;
+    procedure ParsesInputLongerThanLegacyCopyLimit;
+  end;
+
+implementation
+
+procedure TFileTemplatesTest.CheckTemplates(const Input: string;
+  const Expected: array of string);
+var
+  Actual: TFileTemplates;
+  i: integer;
+begin
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', Length(Expected), Length(Actual));
+  for i:=Low(Expected) to High(Expected) do
+    AssertEquals('template ' + IntToStr(i), Expected[i], Actual[i]);
+end;
+
+function TFileTemplatesTest.BuildTemplates(Count: integer): string;
+var
+  i: integer;
+begin
+  Result:='';
+  for i:=1 to Count do begin
+    if Result <> '' then
+      Result:=Result + ' ';
+    Result:=Result + 'template' + IntToStr(i);
+  end;
+end;
+
+procedure TFileTemplatesTest.ParsesEmptyInput;
+begin
+  CheckTemplates('', []);
+end;
+
+procedure TFileTemplatesTest.ParsesSingleTemplate;
+begin
+  CheckTemplates('*.avi', ['*.avi']);
+end;
+
+procedure TFileTemplatesTest.ParsesMultipleTemplates;
+begin
+  CheckTemplates('*.avi *.mkv tom*jerry*.avi',
+    ['*.avi', '*.mkv', 'tom*jerry*.avi']);
+end;
+
+procedure TFileTemplatesTest.IgnoresRepeatedSpaces;
+begin
+  CheckTemplates('  *.avi   *.mkv  ', ['*.avi', '*.mkv']);
+end;
+
+procedure TFileTemplatesTest.PreservesTemplateText;
+begin
+  CheckTemplates('*.AVI Mixed*Case.MKV', ['*.AVI', 'Mixed*Case.MKV']);
+end;
+
+procedure TFileTemplatesTest.SplitsOnlyOnSpaces;
+begin
+  CheckTemplates('*.avi' + #9 + '*.mkv *.mp4',
+    ['*.avi' + #9 + '*.mkv', '*.mp4']);
+end;
+
+procedure TFileTemplatesTest.TrimsControlWhitespaceAtTemplateBoundaries;
+begin
+  CheckTemplates(#9 + '*.avi' + #9 + ' ' + #10 + '*.mkv' + #13 +
+    ' ' + #9 + ' *.mp4' + #9, ['*.avi', '*.mkv', '*.mp4']);
+end;
+
+procedure TFileTemplatesTest.ParsesBeyondLegacyCapacity;
+var
+  Actual: TFileTemplates;
+  Input: string;
+begin
+  Input:=BuildTemplates(52);
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', 52, Length(Actual));
+  AssertEquals('first template', 'template1', Actual[0]);
+  AssertEquals('last template', 'template52', Actual[51]);
+end;
+
+procedure TFileTemplatesTest.ParsesInputLongerThanLegacyCopyLimit;
+var
+  Actual: TFileTemplates;
+  Input: string;
+begin
+  Input:=BuildTemplates(200);
+  AssertTrue('test input must exceed 999 characters', Length(Input) > 999);
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', 200, Length(Actual));
+  AssertEquals('last template', 'template200', Actual[199]);
+end;
+
+initialization
+  RegisterTest(TFileTemplatesTest);
+
+end.

--- a/tests/filetemplates_tests.pas
+++ b/tests/filetemplates_tests.pas
@@ -1,0 +1,148 @@
+unit FileTemplates_Tests;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  SysUtils, fpcunit, testregistry, FileTemplates;
+
+type
+  TFileTemplatesTest = class(TTestCase)
+  private
+    procedure CheckTemplates(const Input: string; const Expected: array of string);
+    function BuildTemplates(Count: integer): string;
+  published
+    procedure ParsesEmptyInput;
+    procedure ParsesSingleTemplate;
+    procedure ParsesMultipleTemplates;
+    procedure IgnoresRepeatedSpaces;
+    procedure PreservesTemplateText;
+    procedure SplitsOnlyOnSpaces;
+    procedure TrimsControlWhitespaceAtTemplateBoundaries;
+    procedure ParsesBeyondLegacyCapacity;
+    procedure ParsesInputLongerThanLegacyCopyLimit;
+    procedure MatchesLongPathBasename;
+    procedure MatchesLongTemplateSuffix;
+    procedure FindsFinalMatchBeyondLegacyCopyLimit;
+  end;
+
+implementation
+
+procedure TFileTemplatesTest.CheckTemplates(const Input: string;
+  const Expected: array of string);
+var
+  Actual: TFileTemplates;
+  i: integer;
+begin
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', Length(Expected), Length(Actual));
+  for i:=Low(Expected) to High(Expected) do
+    AssertEquals('template ' + IntToStr(i), Expected[i], Actual[i]);
+end;
+
+function TFileTemplatesTest.BuildTemplates(Count: integer): string;
+var
+  i: integer;
+begin
+  Result:='';
+  for i:=1 to Count do begin
+    if Result <> '' then
+      Result:=Result + ' ';
+    Result:=Result + 'template' + IntToStr(i);
+  end;
+end;
+
+procedure TFileTemplatesTest.ParsesEmptyInput;
+begin
+  CheckTemplates('', []);
+end;
+
+procedure TFileTemplatesTest.ParsesSingleTemplate;
+begin
+  CheckTemplates('*.avi', ['*.avi']);
+end;
+
+procedure TFileTemplatesTest.ParsesMultipleTemplates;
+begin
+  CheckTemplates('*.avi *.mkv tom*jerry*.avi',
+    ['*.avi', '*.mkv', 'tom*jerry*.avi']);
+end;
+
+procedure TFileTemplatesTest.IgnoresRepeatedSpaces;
+begin
+  CheckTemplates('  *.avi   *.mkv  ', ['*.avi', '*.mkv']);
+end;
+
+procedure TFileTemplatesTest.PreservesTemplateText;
+begin
+  CheckTemplates('*.AVI Mixed*Case.MKV', ['*.AVI', 'Mixed*Case.MKV']);
+end;
+
+procedure TFileTemplatesTest.SplitsOnlyOnSpaces;
+begin
+  CheckTemplates('*.avi' + #9 + '*.mkv *.mp4',
+    ['*.avi' + #9 + '*.mkv', '*.mp4']);
+end;
+
+procedure TFileTemplatesTest.TrimsControlWhitespaceAtTemplateBoundaries;
+begin
+  CheckTemplates(#9 + '*.avi' + #9 + ' ' + #10 + '*.mkv' + #13 +
+    ' ' + #9 + ' *.mp4' + #9, ['*.avi', '*.mkv', '*.mp4']);
+end;
+
+procedure TFileTemplatesTest.ParsesBeyondLegacyCapacity;
+var
+  Actual: TFileTemplates;
+  Input: string;
+begin
+  Input:=BuildTemplates(52);
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', 52, Length(Actual));
+  AssertEquals('first template', 'template1', Actual[0]);
+  AssertEquals('last template', 'template52', Actual[51]);
+end;
+
+procedure TFileTemplatesTest.ParsesInputLongerThanLegacyCopyLimit;
+var
+  Actual: TFileTemplates;
+  Input: string;
+begin
+  Input:=BuildTemplates(200);
+  AssertTrue('test input must exceed 999 characters', Length(Input) > 999);
+  Actual:=ParseFileTemplates(Input);
+  AssertEquals('template count', 200, Length(Actual));
+  AssertEquals('last template', 'template200', Actual[199]);
+end;
+
+procedure TFileTemplatesTest.MatchesLongPathBasename;
+var
+  BaseName: string;
+begin
+  BaseName:=StringOfChar('a', 1000) + '.mkv';
+  AssertTrue('long basename after path separator must remain intact',
+    IsFileTemplate('folder/' + BaseName, [BaseName]));
+end;
+
+procedure TFileTemplatesTest.MatchesLongTemplateSuffix;
+var
+  Suffix: string;
+begin
+  Suffix:=StringOfChar('b', 1000) + '.avi';
+  AssertTrue('template remainder after wildcard must remain intact',
+    IsFileTemplate(Suffix, ['*' + Suffix]));
+end;
+
+procedure TFileTemplatesTest.FindsFinalMatchBeyondLegacyCopyLimit;
+var
+  FileName: string;
+begin
+  FileName:='end' + StringOfChar('x', 1000) + 'end';
+  AssertTrue('filename remainder must not be truncated before the final match',
+    IsFileTemplate(FileName, ['end']));
+end;
+
+initialization
+  RegisterTest(TFileTemplatesTest);
+
+end.

--- a/tests/run_filetemplates_tests.lpr
+++ b/tests/run_filetemplates_tests.lpr
@@ -1,0 +1,18 @@
+program RunFileTemplatesTests;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, consoletestrunner, FileTemplates_Tests;
+
+var
+  TestRunner: TTestRunner;
+begin
+  TestRunner:=TTestRunner.Create(nil);
+  try
+    TestRunner.Initialize;
+    TestRunner.Run;
+  finally
+    TestRunner.Free;
+  end;
+end.


### PR DESCRIPTION
### **User description**
## Motivation

PR #1577 prevents the fixed file-template buffer from being written out of bounds, but parsing still stops after 51 templates. The parser and matcher also retain `Copy(..., 999)` operations that can truncate long template lists, path basenames, template remainders, or filename remainders.

## Changes

- Extract space-separated template parsing and filename matching into a standalone `FileTemplates` unit.
- Store parsed templates in a dynamic array instead of a fixed 51-entry array.
- Remove the remaining 999-character truncation from parsing and matching.
- Preserve the existing template syntax, trimming behavior, and wildcard-matching semantics.
- Add FPCUnit coverage for parser boundaries and long matcher inputs.
- Run the tests in CI and require them before release publication.

The INI format and persisted `FolExt*` values are unchanged. This PR does not otherwise change wildcard rules or case sensitivity; those remain separate follow-ups.

## Testing

- FPCUnit: 12 tests, 0 failures or errors.
- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/`
- `git diff --check`


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Replace fixed template buffers with dynamic arrays.

- Remove 999-character truncation from template matching.

- Add parser and long-input regression coverage.

- Run template tests before release publishing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Input["Folder extension templates"] 
  Parser["Dynamic template parser"]
  Matcher["Unlimited filename matcher"]
  Tests["FPCUnit and CI coverage"]
  Input -- "parses" --> Parser
  Parser -- "supplies templates" --> Matcher
  Tests -- "validates" --> Parser
  Tests -- "validates" --> Matcher
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addtorrent.pas</strong><dd><code>Integrate dynamic template parsing into add dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

addtorrent.pas

<ul><li>Replace fixed 51-entry template storage with <code>TFileTemplates</code>.<br> <li> Delegate template parsing and filename matching to <code>FileTemplates</code>.<br> <li> Preserve extension-based destination folder selection behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1580/files#diff-bb92b745dacc7edd24be2137f0866230a1e31a4d8a0423f94b23292471089b9d">+4/-99</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filetemplates.pas</strong><dd><code>Add reusable unlimited template parsing and matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

filetemplates.pas

<ul><li>Add reusable dynamic parsing for space-separated file templates.<br> <li> Remove fixed-capacity and 999-character copy limits.<br> <li> Move existing wildcard filename matching into a standalone unit.<br> <li> Retain path basename extraction and template matching semantics.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1580/files#diff-00dd6f220bc71fd167d210d2dfdaae23e084379d8c028ef60fca818e9d90a838">+128/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filetemplates_tests.pas</strong><dd><code>Cover template parser and matcher boundary regressions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/filetemplates_tests.pas

<ul><li>Add FPCUnit coverage for template parsing behavior.<br> <li> Test inputs beyond previous capacity and length limits.<br> <li> Verify matching of long basenames and wildcard suffixes.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1580/files#diff-c734628229c130b2bc2b3e61addcb6df84e4b17f60ae0f9172876a0009bab687">+148/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_filetemplates_tests.lpr</strong><dd><code>Add console runner for template unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/run_filetemplates_tests.lpr

<ul><li>Add a console FPCUnit runner for file-template tests.<br> <li> Initialize, execute, and release the test runner.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1580/files#diff-a94e149cb8fb215b51f50cd8c3be775acd4b35e094ac7354821c8f0fc4c2a973">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Run Pascal template tests in continuous integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add a Debian-based Pascal unit-test CI job.<br> <li> Compile and execute the file-template FPCUnit suite.<br> <li> Require template tests before GitHub release publishing.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1580/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved file-template parsing and matching for long inputs, paths, suffixes, and larger template sets.
  * Added reliable handling of whitespace and complex filename patterns.

* **Bug Fixes**
  * Improved matching accuracy for complex templates and filenames.

* **Tests**
  * Added automated coverage for typical and edge-case file-template scenarios.

* **Chores**
  * Release publishing now waits for the file-template test suite to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->