### PR TITLE
Prevent crashes from malformed duplicate-torrent tracker metadata

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -2430,6 +2430,7 @@ var
     i, j: Integer;
     s, tfn, TorrentHash: string;
     TrackersList: TStringList;
+    UseAnnounceFallback: boolean;
   begin
     RpcObj.Status:='';
     s:='';
@@ -2502,17 +2503,26 @@ var
             TorrentHash:=StrToHex(SHA1(s));
           end;
           AnnData:=(TorData.ListData.FindElement('announce-list', False) as TBEncoded);
-          if AnnData <> nil then
+          UseAnnounceFallback:=(AnnData = nil) or (AnnData.Format <> befList);
+          if not UseAnnounceFallback then begin
             for i:=0 to AnnData.ListData.Count - 1 do begin
               LData:=AnnData.ListData.Items[i].Data as TBEncoded;
+              if LData.Format <> befList then begin
+                UseAnnounceFallback:=True;
+                continue;
+              end;
               for j:=0 to LData.ListData.Count - 1 do begin
                 LLData:=LData.ListData.Items[j].Data as TBEncoded;
-                TrackersList.Add(LLData.StringData);
+                if LLData.Format = befString then
+                  TrackersList.Add(LLData.StringData)
+                else
+                  UseAnnounceFallback:=True;
               end;
-            end
-          else begin
+            end;
+          end;
+          if UseAnnounceFallback and (TrackersList.Count = 0) then begin
             AnnData:=(TorData.ListData.FindElement('announce', False) as TBEncoded);
-            if AnnData <> nil then
+            if (AnnData <> nil) and (AnnData.Format = befString) then
               TrackersList.Add(AnnData.StringData);
           end;
         finally


### PR DESCRIPTION
### Motivation

When the daemon reports a duplicate torrent, tracker metadata from the local .torrent file may contain malformed announce-list or announce nodes. Reading those nodes without checking their bencode types can dereference missing list data or turn non-string entries into empty tracker values.

### Description

- Require announce-list and every tracker tier to be bencode lists before iterating them.
- Accept tracker entries and the fallback announce value only when they are bencode strings.
- Fall back to announce when malformed nested announce-list entries yield no string tracker.
- Preserve existing announce-list precedence for structurally valid empty lists and mixed lists that yield a string tracker.

### Testing

- lazbuild -B transgui.lpi
- Exercised 15 bencode shapes covering missing and wrong-type nodes, empty tiers, malformed leaves, mixed valid and invalid entries, and fallback precedence.
- Live daemon integration was not run.