### PR TITLE
Validate pending connections before updating the host list

### DIFF
--- a/connoptions.pas
+++ b/connoptions.pas
@@ -164,6 +164,8 @@ procedure TConnOptionsForm.btRenameClick(Sender: TObject);
 begin
   if edConnection.Visible then begin
     if Trim(edConnection.Text) = '' then exit;
+    if (FCurConn = '') and not Validate then
+      exit;
     EndEdit;
     exit;
   end;
@@ -247,9 +249,11 @@ end;
 
 procedure TConnOptionsForm.btNewClick(Sender: TObject);
 begin
+  if (FCurConn <> '') or (edConnection.Visible and
+    ((Trim(edConnection.Text) <> '') or (Trim(edHost.Text) <> ''))) then
+    if not Validate then
+      exit;
   EndEdit;
-  if (FCurConn <> '') and not Validate then
-    exit;
   SaveConnSettings(FCurConn);
   LoadConnSettings('');
   BeginEdit;


### PR DESCRIPTION
## Summary

- Validate pending new connections before naming or persisting them so
  failed validation cannot partially update the saved host list.
- Preserve empty-form initialization and existing connection renames.

## Related change

- #1597 removes the separate, misleading RPC password warning.

## Testing

- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/3.0`
- `make LAZARUS_DIR=/usr/lib/lazarus/3.0 all`
- `git diff --check origin/master...HEAD`
- Local multi-reviewer code review loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when renaming unsaved connections, ensuring available connection details are checked before editing ends.
  - Adjusted new connection creation so validation occurs when relevant connection details are entered, while allowing truly empty entries to proceed appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->