### PR TITLE
Guard magnet link copy with empty torrent list

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -4850,6 +4850,8 @@ var
   Magnets: TStringList;
 begin
   TorrentIds:=GetSelectedTorrents;
+  if VarIsEmpty(TorrentIds) then
+    exit;
   req:=TJSONObject.Create;
   args:=TJSONObject.Create;
   Magnets:=TStringList.Create;


### PR DESCRIPTION
### Motivation

With RPC >= 7, invoking Copy Magnet Link(s) when the torrent list is empty can call `VarArrayLowBound` and `VarArrayHighBound` on an unassigned variant, causing a runtime exception.

### Description

- Add an early `VarIsEmpty(TorrentIds)` check in `TMainForm.MenuItem101Click`.
- Exit before any variant array bounds access when `GetSelectedTorrents` returns an empty value.
- Keep the existing magnet-link copy behavior unchanged when torrents are selected.

### Testing

- Verified that the empty-selection guard runs before any variant array bounds access.
- Confirmed that the existing path for selected torrents is unchanged.