### PR TITLE
Enable Lazarus runtime safety checks

### DIFF
--- a/transgui.lpi
+++ b/transgui.lpi
@@ -205,6 +205,11 @@
       </SyntaxOptions>
     </Parsing>
     <CodeGeneration>
+      <Checks>
+        <IOChecks Value="True"/>
+        <RangeChecks Value="True"/>
+        <StackChecks Value="True"/>
+      </Checks>
       <SmallerCode Value="True"/>
     </CodeGeneration>
     <Other>


### PR DESCRIPTION
### Motivation

External or corrupted data can otherwise turn invalid I/O, range, or stack conditions into unsafe runtime failures. Enabling project-level runtime checks makes these conditions fail predictably as catchable runtime exceptions.

### Description

- Add a `<Checks>` section under `<CodeGeneration>` in `transgui.lpi`.
- Enable `IOChecks`, `RangeChecks`, and `StackChecks`.
- Preserve the existing `SmallerCode` setting.

### Testing

- Verified that all three runtime checks are enabled in `transgui.lpi`.
- Confirmed that the existing `SmallerCode` setting remains unchanged.