### PR TITLE
Prevent negative speed-history shifts after clock rollback

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -5825,7 +5825,7 @@ var
       end
       else begin
         j:=Round((Now - cardinal(p[0])/SecsPerDay)/RpcObj.RefreshInterval);
-        if j = 0 then
+        if j < 1 then
           j:=1;
       end;
       p[0]:=integer(cardinal(Round(Now*SecsPerDay)));


### PR DESCRIPTION
### Motivation

When the system clock moves backward, `StoreSpeed` can calculate a negative history shift value in `j`. Passing that value into `Move` can cause out-of-bounds reads or writes in the speed history array.

### Description

- Change the lower-bound check in `StoreSpeed` from `j = 0` to `j < 1`.
- Clamp negative or zero elapsed intervals to a one-slot history shift before array movement and averaging.
- Preserve the existing averaging logic and history array size.

### Testing

- Verified behavior for negative, zero, and positive history shift values.
- Confirmed that the history shift is always at least one before array movement.