### PR TITLE
Bound folder history values loaded from INI files

### DIFF
--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -185,7 +185,7 @@ const
 
 implementation
 
-uses lclintf, lcltype, main, variants, Utils, rpc, lclproc;
+uses lclintf, lcltype, main, variants, Utils, rpc, lclproc, FolderHistory;
 
 const
   roChecked   = $030000;
@@ -935,17 +935,17 @@ end;
 
 procedure TAddTorrentForm.DeleteDirs(maxdel : Integer);
 var
-  i,min,max,indx, fldr: integer;
+  i, max, indx: integer;
+  min, fldr: Int64;
   pFD : FolderData;
 begin
-    max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
-    if max < 10 then
-      max:=10;
+    max:=NormalizeFolderHistoryLimit(
+      Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50));
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max); // PETROV
 
     try
       while (cbDestFolder.Items.Count+maxdel) > max do begin
-        min := 9999999;
+        min:=0;
         indx:=-1;
         for i:=0 to cbDestFolder.Items.Count - 1 do begin
           pFD := cbDestFolder.Items.Objects[i] as FolderData;
@@ -955,7 +955,8 @@ begin
           if SysUtils.Date > pFD.Lst then
             fldr := 0- fldr;
 
-          fldr := fldr + pFD.Hit;
+          pFD.Hit:=NormalizeFolderHistoryHit(pFD.Hit);
+          fldr:=fldr + pFD.Hit;
           if (indx < 0) or (fldr < min) then begin
             min := fldr;
             indx:= i;
@@ -997,7 +998,7 @@ begin
       cbDestFolder.Items.Objects[i]:= pFD;
     end else begin
       pFD    := cbDestFolder.Items.Objects[i] as FolderData;
-      pFD.Hit:= pFD.Hit + 1;
+      pFD.Hit:=IncrementFolderHistoryHit(pFD.Hit);
       pFD.Ext:= e;
       pFD.Txt:= s;
       pFD.Lst:= SysUtils.Date;

--- a/connoptions.pas
+++ b/connoptions.pas
@@ -146,7 +146,7 @@ type
 
 implementation
 
-uses Main, synacode, utils, rpc, LCLIntf;
+uses Main, synacode, utils, rpc, LCLIntf, FolderHistory;
 
 { TConnOptionsForm }
 
@@ -580,7 +580,8 @@ begin
     cbUseProxyClick(nil);
   end;
 
-  edMaxFolder.Value:= Ini.ReadInteger('Interface','MaxFoldersHistory', 50); // PETROV
+  edMaxFolder.Value:=NormalizeFolderHistoryLimit(
+    Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50)); // PETROV
 
   FCurConn:=ConnName;
   FCurHost:=edHost.Text;

--- a/folderhistory.pas
+++ b/folderhistory.pas
@@ -1,0 +1,56 @@
+unit FolderHistory;
+
+{$mode objfpc}{$H+}
+
+interface
+
+const
+  MinFolderHistoryItems = 10;
+  MaxFolderHistoryItems = 99;
+  // Legacy writers also touched one terminator key at the count index.
+  MaxFolderHistoryCleanupIndex = MaxFolderHistoryItems;
+
+function NormalizeFolderHistoryLimit(Value: Integer): Integer;
+function NormalizeFolderHistoryCount(Value: Integer): Integer;
+function NormalizeFolderHistoryHit(Value: Integer): Integer;
+function IncrementFolderHistoryHit(Value: Integer): Integer;
+
+implementation
+
+function NormalizeFolderHistoryLimit(Value: Integer): Integer;
+begin
+  if Value < MinFolderHistoryItems then
+    Result:=MinFolderHistoryItems
+  else if Value > MaxFolderHistoryItems then
+    Result:=MaxFolderHistoryItems
+  else
+    Result:=Value;
+end;
+
+function NormalizeFolderHistoryCount(Value: Integer): Integer;
+begin
+  if Value < 0 then
+    Result:=0
+  else if Value > MaxFolderHistoryItems then
+    Result:=MaxFolderHistoryItems
+  else
+    Result:=Value;
+end;
+
+function NormalizeFolderHistoryHit(Value: Integer): Integer;
+begin
+  // Positive values are cumulative usage counts and have no specified cap.
+  if Value < 0 then
+    Result:=0
+  else
+    Result:=Value;
+end;
+
+function IncrementFolderHistoryHit(Value: Integer): Integer;
+begin
+  Result:=NormalizeFolderHistoryHit(Value);
+  if Result < High(Integer) then
+    Inc(Result);
+end;
+
+end.

--- a/main.pas
+++ b/main.pas
@@ -962,7 +962,7 @@ uses
 {$endif darwin}
   synacode, ConnOptions, clipbrd, DateUtils, TorrProps, DaemonOptions, About,
   ToolWin, download, ColSetup, AddLink, MoveTorrent, AddTracker, lcltype,
-  Options, ButtonPanel, BEncode, synautil, Math;
+  Options, ButtonPanel, BEncode, synautil, Math, FolderHistory;
 
   {TMyHashMap}
   function TMyHashMap.DefaultHashKey(const Key: Integer): Integer;
@@ -7918,7 +7918,8 @@ begin
   CB.Items.Clear;
 
   IniSec   := 'AddTorrent.' + FCurConn;
-  j        := Ini.ReadInteger(IniSec, 'FolderCount', 0);
+  j        := NormalizeFolderHistoryCount(
+    Ini.ReadInteger(IniSec, 'FolderCount', 0));
 
   for i:=0 to j - 1 do begin
     s:=Ini.ReadString(IniSec, Format('Folder%d', [i]), '');
@@ -7935,7 +7936,8 @@ begin
       if n=0 then begin
         m      := CB.Items.Add(s);
         pFD    := FolderData.create;
-        pFD.Hit:= Ini.ReadInteger (IniSec, Format('FolHit%d', [i]), 1);
+        pFD.Hit:=NormalizeFolderHistoryHit(
+          Ini.ReadInteger(IniSec, Format('FolHit%d', [i]), 1));
         pFD.Ext:= Ini.ReadString  (IniSec, Format('FolExt%d', [i]),'');
         lastDt := Ini.ReadString  (IniSec, Format('LastDt%d', [i]),'');
         pFD.Txt:= s; // for debug
@@ -7980,7 +7982,7 @@ end;
 
 procedure TMainForm.SaveDownloadDirs(CB: TComboBox; const CurFolderParam: string);
 var
-  i: integer;
+  i, WriteIndex: integer;
   IniSec: string;
   tmp,selfolder : string;
   strdate : string;
@@ -8009,7 +8011,7 @@ begin
       end else begin
           pFD    := CB.Items.Objects[i] as FolderData;
           if pFD <> nil then begin
-            pFD.Hit:= pFD.Hit + 1;
+            pFD.Hit:=IncrementFolderHistoryHit(pFD.Hit);
             pFD.Lst:= Today;
             CB.Items.Objects[i]:= pFD;
           end;
@@ -8021,25 +8023,30 @@ begin
   end;
 
   try
-    Ini.WriteInteger(IniSec, 'FolderCount', CB.Items.Count);
+    WriteIndex:=0;
     for i:=0 to CB.Items.Count - 1 do begin
-      tmp := CorrectPath(CB.Items[i]);
-      pFD := CB.Items.Objects[i] as FolderData;
-      if pFD = nil then continue;
+      if WriteIndex >= MaxFolderHistoryItems then break;
+      tmp:=CorrectPath(CB.Items[i]);
+      pFD:=CB.Items.Objects[i] as FolderData;
+      if (tmp = '') or (pFD = nil) then continue;
 
-      Ini.WriteString (IniSec, Format('Folder%d', [i]), tmp);
-      Ini.WriteInteger(IniSec, Format('FolHit%d', [i]), pFD.Hit);
-      Ini.WriteString (IniSec, Format('FolExt%d', [i]), pFD.Ext);
+      Ini.WriteString(IniSec, Format('Folder%d', [WriteIndex]), tmp);
+      Ini.WriteInteger(IniSec, Format('FolHit%d', [WriteIndex]),
+        NormalizeFolderHistoryHit(pFD.Hit));
+      Ini.WriteString(IniSec, Format('FolExt%d', [WriteIndex]), pFD.Ext);
 
       DateTimeToString(strdate, 'dd.mm.yyyy', pFD.Lst);
-      Ini.WriteString (IniSec, Format('LastDt%d', [i]), strdate);
+      Ini.WriteString(IniSec, Format('LastDt%d', [WriteIndex]), strdate);
+      Inc(WriteIndex);
     end;
+    Ini.WriteInteger(IniSec, 'FolderCount', WriteIndex);
 
-    // clear string
-    Ini.WriteString (IniSec, Format('Folder%d', [i+1]), '' );
-    Ini.WriteInteger(IniSec, Format('FolHit%d', [i+1]), -1 );
-    Ini.WriteString (IniSec, Format('FolExt%d', [i+1]), '' );
-    Ini.WriteString (IniSec, Format('LastDt%d', [i+1]), '' );
+    for i:=WriteIndex to MaxFolderHistoryCleanupIndex do begin
+      Ini.DeleteKey(IniSec, Format('Folder%d', [i]));
+      Ini.DeleteKey(IniSec, Format('FolHit%d', [i]));
+      Ini.DeleteKey(IniSec, Format('FolExt%d', [i]));
+      Ini.DeleteKey(IniSec, Format('LastDt%d', [i]));
+    end;
   except
     MessageDlg('Error: LS-009. Please contact the developer', mtError, [mbOK], 0);
   end;
@@ -8050,17 +8057,17 @@ end;
 
 procedure TMainForm.DeleteDirs(CB: TComboBox; maxdel : Integer);
 var
-  i,min,max,indx, fldr: integer;
+  i, max, indx: integer;
+  min, fldr: Int64;
   pFD : FolderData;
 begin
-    max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
-    if max < 10 then
-      max:=10;
+    max:=NormalizeFolderHistoryLimit(
+      Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50));
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max);
 
     try
     while (CB.Items.Count+maxdel) > max do begin
-      min := 9999999;
+      min:=0;
       indx:=-1;
       for i:=0 to CB.Items.Count - 1 do begin
         pFD := CB.Items.Objects[i] as FolderData;
@@ -8070,7 +8077,8 @@ begin
         if Today > pFD.Lst then
           fldr := 0- fldr;
 
-        fldr := fldr + pFD.Hit;
+        pFD.Hit:=NormalizeFolderHistoryHit(pFD.Hit);
+        fldr:=fldr + pFD.Hit;
         if (indx < 0) or (fldr < min) then begin
           min := fldr;
           indx:= i;


### PR DESCRIPTION
### **User description**
### Motivation

Folder history data is read from INI files that may be imported, manually edited, or damaged. `FolderCount` was trusted as a loop bound, values above the UI history limit were accepted, negative hit counters were not repaired, and score arithmetic could overflow.

Saving also wrote `FolderCount` before skipping invalid entries. That could leave sparse metadata, an inaccurate count, and stale keys.

### Description

- Define the existing folder history range of 10 to 99 in a small shared unit.
- Clamp loaded history limits and stored counts, and repair negative hit counters.
- Keep positive hit values as cumulative usage counts while saturating increments and calculating pruning scores with `Int64`.
- Read at most 99 persisted history entries without writing during the load path.
- Save only non-empty entries with valid metadata using contiguous indices.
- Write the actual saved count and clear stale keys across the fixed supported range.
- Explicitly include the legacy terminator key at index 99 in cleanup.

### Scope

This PR only hardens INI input and persistence. Ownership and cleanup of `FolderData` objects are handled separately in #1589.

### Testing

- `git diff --check`
- Guarded source rewrite checks verified the exact changed-file set.
- Cross-platform GitHub Actions CI passed on the final commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Folder history settings are now validated and kept within supported limits.
  * Folder usage counts are normalized and safely capped to prevent invalid or excessive values.
  * History maintenance removes invalid and outdated entries, compacts stored records, and enforces the configured maximum.
  * Existing folder activity continues to be tracked correctly when entries are reused.
  * Stored history remains consistent and reliable across loading, updating, and saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Clamp configured folder-history limits and persisted counts.

- Normalize hits, prevent increment overflow, widen pruning scores.

- Save contiguous valid entries and remove stale keys.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["INI folder history values"]
  Normalize["Normalize limits, counts, and hits"]
  History["In-memory folder history"]
  Persist["Contiguous persisted history entries"]
  Config -- "is validated" --> Normalize
  Normalize -- "populates and updates" --> History
  History -- "writes valid entries" --> Persist
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addtorrent.pas</strong><dd><code>Harden add-torrent folder history pruning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

addtorrent.pas

<ul><li>Normalize the configured destination-folder history limit.<br> <li> Use <code>Int64</code> pruning scores for large hit counts.<br> <li> Repair negative hits and saturate usage increments.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1588/files#diff-bb92b745dacc7edd24be2137f0866230a1e31a4d8a0423f94b23292471089b9d">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>connoptions.pas</strong><dd><code>Display bounded folder history setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

connoptions.pas

<ul><li>Normalize <code>MaxFoldersHistory</code> before displaying its configured value.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1588/files#diff-6eba056e2fa3a966f860694c05571bd7a2604eb9952cb470ef41720c6ee0b3e8">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.pas</strong><dd><code>Validate and compact saved folder history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.pas

<ul><li>Bound loaded folder counts and normalize loaded hit counters.<br> <li> Use <code>Int64</code> scoring while pruning outdated history entries.<br> <li> Persist only valid non-empty entries with contiguous indices.<br> <li> Delete stale folder metadata keys through the supported range.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1588/files#diff-449243edd8ba91d6d43d39c7bb109819a01e7c4e75770a16698291e7a6eb2363">+32/-24</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>folderhistory.pas</strong><dd><code>Add shared folder history validation helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

folderhistory.pas

<ul><li>Add shared folder-history minimum and maximum constants.<br> <li> Normalize configured limits, stored counts, and hit values.<br> <li> Saturate hit increments at <code>High(Integer)</code>.<br> <li> Define the legacy cleanup index for persisted keys.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1588/files#diff-41906a8f1f465d5c61cff7ee7f36b1a7c8c65690b3adbbfa9116023c3dbd1dcc">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

