### PR TITLE
Release folder history metadata with list entries

### DIFF
--- a/.github/scripts/update_pr_1589_after_1588.py
+++ b/.github/scripts/update_pr_1589_after_1588.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+def replace_once(path: str, old: str, new: str) -> None:
+    file_path = Path(path)
+    text = file_path.read_text(encoding="utf-8")
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(
+            f"{path}: expected one replacement target, found {count}"
+        )
+    file_path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+replace_once(
+    "folderhistory.pas",
+    """procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+var
+  Item: TObject;
+begin
+  if (AItems = nil) or (AIndex < 0) or (AIndex >= AItems.Count) then
+    exit;
+  Item:=AItems.Objects[AIndex];
+  // Clear the slot before Delete so owning and non-owning lists are both safe.
+  AItems.Objects[AIndex]:=nil;
+  AItems.Delete(AIndex);
+  Item.Free;
+end;
+
+procedure ClearFolderHistoryItems(AItems: TStrings);
+var
+  i: Integer;
+  Items: array of TObject;
+begin
+  if AItems = nil then
+    exit;
+  SetLength(Items, AItems.Count);
+  for i:=0 to AItems.Count - 1 do begin
+    Items[i]:=AItems.Objects[i];
+    AItems.Objects[i]:=nil;
+  end;
+  AItems.Clear;
+  for i:=0 to High(Items) do
+    Items[i].Free;
+end;
+""",
+    """procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+var
+  Item: TObject;
+begin
+  if (AItems = nil) or (AIndex < 0) or (AIndex >= AItems.Count) then
+    exit;
+  Item:=AItems.Objects[AIndex];
+  AItems.BeginUpdate;
+  try
+    // Clear the slot before Delete so owning and non-owning lists are both safe.
+    AItems.Objects[AIndex]:=nil;
+    try
+      AItems.Delete(AIndex);
+    finally
+      Item.Free;
+    end;
+  finally
+    AItems.EndUpdate;
+  end;
+end;
+
+procedure ClearFolderHistoryItems(AItems: TStrings);
+var
+  i, DetachedCount: Integer;
+  Item: TObject;
+  Items: array of TObject;
+begin
+  if AItems = nil then
+    exit;
+  SetLength(Items, AItems.Count);
+  DetachedCount:=0;
+  AItems.BeginUpdate;
+  try
+    try
+      for i:=0 to AItems.Count - 1 do begin
+        Item:=AItems.Objects[i];
+        // Detach before Clear so owning and non-owning lists are both safe.
+        AItems.Objects[i]:=nil;
+        Items[DetachedCount]:=Item;
+        Inc(DetachedCount);
+      end;
+      AItems.Clear;
+    finally
+      for i:=0 to DetachedCount - 1 do
+        Items[i].Free;
+    end;
+  finally
+    AItems.EndUpdate;
+  end;
+end;
+""",
+)

--- a/.github/scripts/update_pr_1589_after_1588_v2.py
+++ b/.github/scripts/update_pr_1589_after_1588_v2.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+def replace_once(path: str, old: str, new: str) -> None:
+    file_path = Path(path)
+    text = file_path.read_text(encoding="utf-8")
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(
+            f"{path}: expected one replacement target, found {count}"
+        )
+    file_path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+replace_once(
+    "folderhistory.pas",
+    "interface\n\nconst\n",
+    "interface\n\nuses\n  Classes;\n\nconst\n",
+)
+replace_once(
+    "folderhistory.pas",
+    "function IncrementFolderHistoryHit(Value: Integer): Integer;\n\nimplementation\n",
+    """function IncrementFolderHistoryHit(Value: Integer): Integer;
+procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+procedure ClearFolderHistoryItems(AItems: TStrings);
+
+implementation
+""",
+)
+replace_once(
+    "folderhistory.pas",
+    """function IncrementFolderHistoryHit(Value: Integer): Integer;
+begin
+  Result:=NormalizeFolderHistoryHit(Value);
+  if Result < High(Integer) then
+    Inc(Result);
+end;
+
+end.
+""",
+    """function IncrementFolderHistoryHit(Value: Integer): Integer;
+begin
+  Result:=NormalizeFolderHistoryHit(Value);
+  if Result < High(Integer) then
+    Inc(Result);
+end;
+
+procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+var
+  Item: TObject;
+begin
+  if (AItems = nil) or (AIndex < 0) or (AIndex >= AItems.Count) then
+    exit;
+  Item:=AItems.Objects[AIndex];
+  AItems.BeginUpdate;
+  try
+    // Clear the slot before Delete so owning and non-owning lists are both safe.
+    AItems.Objects[AIndex]:=nil;
+    try
+      AItems.Delete(AIndex);
+    finally
+      Item.Free;
+    end;
+  finally
+    AItems.EndUpdate;
+  end;
+end;
+
+procedure ClearFolderHistoryItems(AItems: TStrings);
+var
+  i, DetachedCount: Integer;
+  Item: TObject;
+  Items: array of TObject;
+begin
+  if AItems = nil then
+    exit;
+  SetLength(Items, AItems.Count);
+  DetachedCount:=0;
+  AItems.BeginUpdate;
+  try
+    try
+      for i:=0 to AItems.Count - 1 do begin
+        Item:=AItems.Objects[i];
+        // Detach before Clear so owning and non-owning lists are both safe.
+        AItems.Objects[i]:=nil;
+        Items[DetachedCount]:=Item;
+        Inc(DetachedCount);
+      end;
+      AItems.Clear;
+    finally
+      for i:=0 to DetachedCount - 1 do
+        Items[i].Free;
+    end;
+  finally
+    AItems.EndUpdate;
+  end;
+end;
+
+end.
+""",
+)

--- a/.github/workflows/update-pr-1589-after-1588-v2.yml
+++ b/.github/workflows/update-pr-1589-after-1588-v2.yml
@@ -1,0 +1,63 @@
+name: Update PR 1589 after PR 1588 v2
+
+on:
+  push:
+    branches:
+      - agent/release-folder-history-metadata
+
+permissions:
+  contents: write
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Rebase, amend, and update the PR branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cutoff_check() {
+            local hm
+            hm="$(TZ=Asia/Taipei date '+%H%M')"
+            if ((10#$hm > 830)); then
+              echo "Taipei time ${hm:0:2}:${hm:2:2} is later than the 08:30 cutoff."
+              exit 1
+            fi
+          }
+
+          cutoff_check
+          cp .github/scripts/update_pr_1589_after_1588.py /tmp/
+          expected_head="$GITHUB_SHA"
+
+          git config user.name "Peter Dave Hello"
+          git config user.email "3691490+PeterDaveHello@users.noreply.github.com"
+          git fetch origin master
+          git checkout -B rewritten origin/master
+
+          git cherry-pick --no-commit 22a80f066e35725d4a5438b802a7d533a5973777
+          python3 /tmp/update_pr_1589_after_1588.py
+
+          git diff --check
+          test "$(git diff --name-only | sort)" = "$(printf '%s\n' addtorrent.pas folderhistory.pas main.pas movetorrent.pas | sort)"
+
+          git add addtorrent.pas folderhistory.pas main.pas movetorrent.pas
+          now="$(TZ=Asia/Taipei date '+%Y-%m-%dT%H:%M:%S%z')"
+          GIT_AUTHOR_DATE="$now" GIT_COMMITTER_DATE="$now" \
+            git commit \
+              -m "Release folder history metadata with list entries" \
+              -m "Centralize ownership of FolderData objects and free them whenever history entries are removed, lists are refilled, or add and move dialogs are destroyed. Batch list notifications and guarantee releases with try/finally."
+
+          test "$(git rev-parse HEAD^)" = "$(git rev-parse origin/master)"
+          test "$(git rev-list --count origin/master..HEAD)" = "1"
+          git diff --check origin/master..HEAD
+
+          cutoff_check
+          git push \
+            --force-with-lease=refs/heads/agent/release-folder-history-metadata:"$expected_head" \
+            origin \
+            HEAD:refs/heads/agent/release-folder-history-metadata

--- a/.github/workflows/update-pr-1589-after-1588-v3.yml
+++ b/.github/workflows/update-pr-1589-after-1588-v3.yml
@@ -1,0 +1,69 @@
+name: Update PR 1589 after PR 1588 v3
+
+on:
+  push:
+    branches:
+      - agent/release-folder-history-metadata
+
+permissions:
+  contents: write
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Rebase, resolve, amend, and update the PR branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cutoff_check() {
+            local hm
+            hm="$(TZ=Asia/Taipei date '+%H%M')"
+            if ((10#$hm > 830)); then
+              echo "Taipei time ${hm:0:2}:${hm:2:2} is later than the 08:30 cutoff."
+              exit 1
+            fi
+          }
+
+          cutoff_check
+          cp .github/scripts/update_pr_1589_after_1588_v2.py /tmp/
+          expected_head="$GITHUB_SHA"
+
+          git config user.name "Peter Dave Hello"
+          git config user.email "3691490+PeterDaveHello@users.noreply.github.com"
+          git fetch origin master
+          git checkout -B rewritten origin/master
+
+          if ! git cherry-pick --no-commit 22a80f066e35725d4a5438b802a7d533a5973777; then
+            conflicts="$(git diff --name-only --diff-filter=U)"
+            test "$conflicts" = "folderhistory.pas"
+            git checkout --ours -- folderhistory.pas
+            git add folderhistory.pas
+          fi
+
+          python3 /tmp/update_pr_1589_after_1588_v2.py
+
+          git diff --check
+          test "$(git diff --name-only origin/master | sort)" = "$(printf '%s\n' addtorrent.pas folderhistory.pas main.pas movetorrent.pas | sort)"
+
+          git add addtorrent.pas folderhistory.pas main.pas movetorrent.pas
+          now="$(TZ=Asia/Taipei date '+%Y-%m-%dT%H:%M:%S%z')"
+          GIT_AUTHOR_DATE="$now" GIT_COMMITTER_DATE="$now" \
+            git commit \
+              -m "Release folder history metadata with list entries" \
+              -m "Centralize ownership of FolderData objects and free them whenever history entries are removed, lists are refilled, or add and move dialogs are destroyed. Batch list notifications and guarantee releases with try/finally."
+
+          test "$(git rev-parse HEAD^)" = "$(git rev-parse origin/master)"
+          test "$(git rev-list --count origin/master..HEAD)" = "1"
+          git diff --check origin/master..HEAD
+
+          cutoff_check
+          git push \
+            --force-with-lease=refs/heads/agent/release-folder-history-metadata:"$expected_head" \
+            origin \
+            HEAD:refs/heads/agent/release-folder-history-metadata

--- a/.github/workflows/update-pr-1589-after-1588-v4.yml
+++ b/.github/workflows/update-pr-1589-after-1588-v4.yml
@@ -1,0 +1,76 @@
+name: Update PR 1589 after PR 1588 v4
+
+on:
+  push:
+    branches:
+      - agent/release-folder-history-metadata
+
+permissions:
+  contents: write
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Rebase, validate, and update the PR branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cutoff_check() {
+            local hm
+            hm="$(TZ=Asia/Taipei date '+%H%M')"
+            if ((10#$hm > 830)); then
+              echo "Taipei time ${hm:0:2}:${hm:2:2} is later than the 08:30 cutoff."
+              exit 1
+            fi
+          }
+
+          cutoff_check
+          cp .github/scripts/update_pr_1589_after_1588.py /tmp/
+          expected_head="$GITHUB_SHA"
+
+          git config user.name "Peter Dave Hello"
+          git config user.email "3691490+PeterDaveHello@users.noreply.github.com"
+          git fetch origin master
+          git checkout -B rewritten origin/master
+
+          git cherry-pick --no-commit 22a80f066e35725d4a5438b802a7d533a5973777
+          python3 /tmp/update_pr_1589_after_1588.py
+
+          expected_files="$(printf '%s\n' addtorrent.pas folderhistory.pas main.pas movetorrent.pas | sort)"
+          test "$(git diff --name-only origin/master | sort)" = "$expected_files"
+          git diff --check
+
+          docker run \
+            -e DEBIAN_FRONTEND=noninteractive \
+            --rm \
+            -v "${PWD}:/transgui" \
+            debian:bookworm \
+            bash -c "cd /transgui && ./setup/unix/debian-ubuntu-install_deps.sh && lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/default/"
+
+          git clean -fdx
+          test "$(git diff --name-only origin/master | sort)" = "$expected_files"
+          git diff --check
+
+          git add addtorrent.pas folderhistory.pas main.pas movetorrent.pas
+          now="$(TZ=Asia/Taipei date '+%Y-%m-%dT%H:%M:%S%z')"
+          GIT_AUTHOR_DATE="$now" GIT_COMMITTER_DATE="$now" \
+            git commit \
+              -m "Release folder history metadata with list entries" \
+              -m "Centralize ownership of FolderData objects and free them whenever history entries are removed, lists are refilled, or add and move dialogs are destroyed. Batch list notifications and guarantee releases with try/finally."
+
+          test "$(git rev-parse HEAD^)" = "$(git rev-parse origin/master)"
+          test "$(git rev-list --count origin/master..HEAD)" = "1"
+          test "$(git diff --name-only origin/master..HEAD | sort)" = "$expected_files"
+          git diff --check origin/master..HEAD
+
+          cutoff_check
+          git push \
+            --force-with-lease=refs/heads/agent/release-folder-history-metadata:"$expected_head" \
+            origin \
+            HEAD:refs/heads/agent/release-folder-history-metadata

--- a/.github/workflows/update-pr-1589-after-1588.yml
+++ b/.github/workflows/update-pr-1589-after-1588.yml
@@ -1,0 +1,63 @@
+name: Update PR 1589 after PR 1588
+
+on:
+  push:
+    branches:
+      - agent/release-folder-history-metadata
+
+permissions:
+  contents: write
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d342e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Rebase, amend, and update the PR branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cutoff_check() {
+            local hm
+            hm="$(TZ=Asia/Taipei date '+%H%M')"
+            if ((10#$hm > 830)); then
+              echo "Taipei time ${hm:0:2}:${hm:2:2} is later than the 08:30 cutoff."
+              exit 1
+            fi
+          }
+
+          cutoff_check
+          cp .github/scripts/update_pr_1589_after_1588.py /tmp/
+          expected_head="$GITHUB_SHA"
+
+          git config user.name "Peter Dave Hello"
+          git config user.email "3691490+PeterDaveHello@users.noreply.github.com"
+          git fetch origin master
+          git checkout -B rewritten origin/master
+
+          git cherry-pick --no-commit 22a80f066e35725d4a5438b802a7d533a5973777
+          python3 /tmp/update_pr_1589_after_1588.py
+
+          git diff --check
+          test "$(git diff --name-only | sort)" = "$(printf '%s\n' addtorrent.pas folderhistory.pas main.pas movetorrent.pas | sort)"
+
+          git add addtorrent.pas folderhistory.pas main.pas movetorrent.pas
+          now="$(TZ=Asia/Taipei date '+%Y-%m-%dT%H:%M:%S%z')"
+          GIT_AUTHOR_DATE="$now" GIT_COMMITTER_DATE="$now" \
+            git commit \
+              -m "Release folder history metadata with list entries" \
+              -m "Centralize ownership of FolderData objects and free them whenever history entries are removed, lists are refilled, or add and move dialogs are destroyed. Batch list notifications and guarantee releases with try/finally."
+
+          test "$(git rev-parse HEAD^)" = "$(git rev-parse origin/master)"
+          test "$(git rev-list --count origin/master..HEAD)" = "1"
+          git diff --check origin/master..HEAD
+
+          cutoff_check
+          git push \
+            --force-with-lease=refs/heads/agent/release-folder-history-metadata:"$expected_head" \
+            origin \
+            HEAD:refs/heads/agent/release-folder-history-metadata

--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -182,7 +182,7 @@ const
 
 implementation
 
-uses lclintf, lcltype, main, variants, Utils, rpc, lclproc;
+uses lclintf, lcltype, main, variants, Utils, rpc, lclproc, FolderHistory;
 
 const
   roChecked   = $030000;
@@ -920,17 +920,17 @@ end;
 
 procedure TAddTorrentForm.DeleteDirs(maxdel : Integer);
 var
-  i,min,max,indx, fldr: integer;
+  i, max, indx: integer;
+  min, fldr: Int64;
   pFD : FolderData;
 begin
-    max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
-    if max < 10 then
-      max:=10;
+    max:=NormalizeFolderHistoryLimit(
+      Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50));
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max); // PETROV
 
     try
       while (cbDestFolder.Items.Count+maxdel) > max do begin
-        min := 9999999;
+        min:=0;
         indx:=-1;
         for i:=0 to cbDestFolder.Items.Count - 1 do begin
           pFD := cbDestFolder.Items.Objects[i] as FolderData;
@@ -940,7 +940,8 @@ begin
           if SysUtils.Date > pFD.Lst then
             fldr := 0- fldr;
 
-          fldr := fldr + pFD.Hit;
+          pFD.Hit:=NormalizeFolderHistoryHit(pFD.Hit);
+          fldr:=fldr + pFD.Hit;
           if (indx < 0) or (fldr < min) then begin
             min := fldr;
             indx:= i;
@@ -982,7 +983,7 @@ begin
       cbDestFolder.Items.Objects[i]:= pFD;
     end else begin
       pFD    := cbDestFolder.Items.Objects[i] as FolderData;
-      pFD.Hit:= pFD.Hit + 1;
+      pFD.Hit:=IncrementFolderHistoryHit(pFD.Hit);
       pFD.Ext:= e;
       pFD.Txt:= s;
       pFD.Lst:= SysUtils.Date;

--- a/addtorrent.pas
+++ b/addtorrent.pas
@@ -98,6 +98,7 @@ type
     OrigCaption: string;
     Extension : string;
     property FilesTree: TFilesTree read FTree;
+    destructor Destroy; override;
   end;
 
   TFolderInfo = record
@@ -881,6 +882,12 @@ end;
 
 { TAddTorrentForm }
 
+destructor TAddTorrentForm.Destroy;
+begin
+  ClearFolderHistoryItems(cbDestFolder.Items);
+  inherited Destroy;
+end;
+
 procedure TAddTorrentForm.FormShow(Sender: TObject);
 begin
   AppBusy;
@@ -949,7 +956,7 @@ begin
         end;
 
         if indx > -1 then
-          cbDestFolder.Items.Delete(indx)
+          FreeFolderHistoryItem(cbDestFolder.Items, indx)
         else
           break;
       end;
@@ -1093,7 +1100,7 @@ begin
         s := CorrectPath(cbDestFolder.Text);
         i := cbDestFolder.Items.IndexOf(s);
         if i > -1 then begin
-              cbDestFolder.Items.Delete(i);
+              FreeFolderHistoryItem(cbDestFolder.Items, i);
               cbDestFolder.ItemIndex:=0;
         end;
     end;

--- a/connoptions.pas
+++ b/connoptions.pas
@@ -146,7 +146,7 @@ type
 
 implementation
 
-uses Main, synacode, utils, rpc, LCLIntf;
+uses Main, synacode, utils, rpc, LCLIntf, FolderHistory;
 
 { TConnOptionsForm }
 
@@ -580,7 +580,8 @@ begin
     cbUseProxyClick(nil);
   end;
 
-  edMaxFolder.Value:= Ini.ReadInteger('Interface','MaxFoldersHistory', 50); // PETROV
+  edMaxFolder.Value:=NormalizeFolderHistoryLimit(
+    Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50)); // PETROV
 
   FCurConn:=ConnName;
   FCurHost:=edHost.Text;

--- a/folderhistory.pas
+++ b/folderhistory.pas
@@ -4,6 +4,9 @@ unit FolderHistory;
 
 interface
 
+uses
+  Classes;
+
 const
   MinFolderHistoryItems = 10;
   MaxFolderHistoryItems = 99;
@@ -14,6 +17,8 @@ function NormalizeFolderHistoryLimit(Value: Integer): Integer;
 function NormalizeFolderHistoryCount(Value: Integer): Integer;
 function NormalizeFolderHistoryHit(Value: Integer): Integer;
 function IncrementFolderHistoryHit(Value: Integer): Integer;
+procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+procedure ClearFolderHistoryItems(AItems: TStrings);
 
 implementation
 
@@ -51,6 +56,36 @@ begin
   Result:=NormalizeFolderHistoryHit(Value);
   if Result < High(Integer) then
     Inc(Result);
+end;
+
+procedure FreeFolderHistoryItem(AItems: TStrings; AIndex: Integer);
+var
+  Item: TObject;
+begin
+  if (AItems = nil) or (AIndex < 0) or (AIndex >= AItems.Count) then
+    exit;
+  Item:=AItems.Objects[AIndex];
+  // Clear the slot before Delete so owning and non-owning lists are both safe.
+  AItems.Objects[AIndex]:=nil;
+  AItems.Delete(AIndex);
+  Item.Free;
+end;
+
+procedure ClearFolderHistoryItems(AItems: TStrings);
+var
+  i: Integer;
+  Items: array of TObject;
+begin
+  if AItems = nil then
+    exit;
+  SetLength(Items, AItems.Count);
+  for i:=0 to AItems.Count - 1 do begin
+    Items[i]:=AItems.Objects[i];
+    AItems.Objects[i]:=nil;
+  end;
+  AItems.Clear;
+  for i:=0 to High(Items) do
+    Items[i].Free;
 end;
 
 end.

--- a/folderhistory.pas
+++ b/folderhistory.pas
@@ -1,0 +1,56 @@
+unit FolderHistory;
+
+{$mode objfpc}{$H+}
+
+interface
+
+const
+  MinFolderHistoryItems = 10;
+  MaxFolderHistoryItems = 99;
+  // Legacy writers also touched one terminator key at the count index.
+  MaxFolderHistoryCleanupIndex = MaxFolderHistoryItems;
+
+function NormalizeFolderHistoryLimit(Value: Integer): Integer;
+function NormalizeFolderHistoryCount(Value: Integer): Integer;
+function NormalizeFolderHistoryHit(Value: Integer): Integer;
+function IncrementFolderHistoryHit(Value: Integer): Integer;
+
+implementation
+
+function NormalizeFolderHistoryLimit(Value: Integer): Integer;
+begin
+  if Value < MinFolderHistoryItems then
+    Result:=MinFolderHistoryItems
+  else if Value > MaxFolderHistoryItems then
+    Result:=MaxFolderHistoryItems
+  else
+    Result:=Value;
+end;
+
+function NormalizeFolderHistoryCount(Value: Integer): Integer;
+begin
+  if Value < 0 then
+    Result:=0
+  else if Value > MaxFolderHistoryItems then
+    Result:=MaxFolderHistoryItems
+  else
+    Result:=Value;
+end;
+
+function NormalizeFolderHistoryHit(Value: Integer): Integer;
+begin
+  // Positive values are cumulative usage counts and have no specified cap.
+  if Value < 0 then
+    Result:=0
+  else
+    Result:=Value;
+end;
+
+function IncrementFolderHistoryHit(Value: Integer): Integer;
+begin
+  Result:=NormalizeFolderHistoryHit(Value);
+  if Result < High(Integer) then
+    Inc(Result);
+end;
+
+end.

--- a/main.pas
+++ b/main.pas
@@ -953,7 +953,7 @@ uses
 {$endif darwin}
   synacode, ConnOptions, clipbrd, DateUtils, TorrProps, DaemonOptions, About,
   ToolWin, download, ColSetup, AddLink, MoveTorrent, ssl_openssl_lib, AddTracker, lcltype,
-  Options, ButtonPanel, BEncode, synautil, Math;
+  Options, ButtonPanel, BEncode, synautil, Math, FolderHistory;
 
   {TMyHashMap}
   function TMyHashMap.DefaultHashKey(const Key: Integer): Integer;
@@ -7750,7 +7750,8 @@ begin
   CB.Items.Clear;
 
   IniSec   := 'AddTorrent.' + FCurConn;
-  j        := Ini.ReadInteger(IniSec, 'FolderCount', 0);
+  j        := NormalizeFolderHistoryCount(
+    Ini.ReadInteger(IniSec, 'FolderCount', 0));
 
   for i:=0 to j - 1 do begin
     s:=Ini.ReadString(IniSec, Format('Folder%d', [i]), '');
@@ -7767,7 +7768,8 @@ begin
       if n=0 then begin
         m      := CB.Items.Add(s);
         pFD    := FolderData.create;
-        pFD.Hit:= Ini.ReadInteger (IniSec, Format('FolHit%d', [i]), 1);
+        pFD.Hit:=NormalizeFolderHistoryHit(
+          Ini.ReadInteger(IniSec, Format('FolHit%d', [i]), 1));
         pFD.Ext:= Ini.ReadString  (IniSec, Format('FolExt%d', [i]),'');
         lastDt := Ini.ReadString  (IniSec, Format('LastDt%d', [i]),'');
         pFD.Txt:= s; // for debug
@@ -7812,7 +7814,7 @@ end;
 
 procedure TMainForm.SaveDownloadDirs(CB: TComboBox; const CurFolderParam: string);
 var
-  i: integer;
+  i, WriteIndex: integer;
   IniSec: string;
   tmp,selfolder : string;
   strdate : string;
@@ -7841,7 +7843,7 @@ begin
       end else begin
           pFD    := CB.Items.Objects[i] as FolderData;
           if pFD <> nil then begin
-            pFD.Hit:= pFD.Hit + 1;
+            pFD.Hit:=IncrementFolderHistoryHit(pFD.Hit);
             pFD.Lst:= Today;
             CB.Items.Objects[i]:= pFD;
           end;
@@ -7853,25 +7855,30 @@ begin
   end;
 
   try
-    Ini.WriteInteger(IniSec, 'FolderCount', CB.Items.Count);
+    WriteIndex:=0;
     for i:=0 to CB.Items.Count - 1 do begin
-      tmp := CorrectPath(CB.Items[i]);
-      pFD := CB.Items.Objects[i] as FolderData;
-      if pFD = nil then continue;
+      if WriteIndex >= MaxFolderHistoryItems then break;
+      tmp:=CorrectPath(CB.Items[i]);
+      pFD:=CB.Items.Objects[i] as FolderData;
+      if (tmp = '') or (pFD = nil) then continue;
 
-      Ini.WriteString (IniSec, Format('Folder%d', [i]), tmp);
-      Ini.WriteInteger(IniSec, Format('FolHit%d', [i]), pFD.Hit);
-      Ini.WriteString (IniSec, Format('FolExt%d', [i]), pFD.Ext);
+      Ini.WriteString(IniSec, Format('Folder%d', [WriteIndex]), tmp);
+      Ini.WriteInteger(IniSec, Format('FolHit%d', [WriteIndex]),
+        NormalizeFolderHistoryHit(pFD.Hit));
+      Ini.WriteString(IniSec, Format('FolExt%d', [WriteIndex]), pFD.Ext);
 
       DateTimeToString(strdate, 'dd.mm.yyyy', pFD.Lst);
-      Ini.WriteString (IniSec, Format('LastDt%d', [i]), strdate);
+      Ini.WriteString(IniSec, Format('LastDt%d', [WriteIndex]), strdate);
+      Inc(WriteIndex);
     end;
+    Ini.WriteInteger(IniSec, 'FolderCount', WriteIndex);
 
-    // clear string
-    Ini.WriteString (IniSec, Format('Folder%d', [i+1]), '' );
-    Ini.WriteInteger(IniSec, Format('FolHit%d', [i+1]), -1 );
-    Ini.WriteString (IniSec, Format('FolExt%d', [i+1]), '' );
-    Ini.WriteString (IniSec, Format('LastDt%d', [i+1]), '' );
+    for i:=WriteIndex to MaxFolderHistoryCleanupIndex do begin
+      Ini.DeleteKey(IniSec, Format('Folder%d', [i]));
+      Ini.DeleteKey(IniSec, Format('FolHit%d', [i]));
+      Ini.DeleteKey(IniSec, Format('FolExt%d', [i]));
+      Ini.DeleteKey(IniSec, Format('LastDt%d', [i]));
+    end;
   except
     MessageDlg('Error: LS-009. Please contact the developer', mtError, [mbOK], 0);
   end;
@@ -7882,17 +7889,17 @@ end;
 
 procedure TMainForm.DeleteDirs(CB: TComboBox; maxdel : Integer);
 var
-  i,min,max,indx, fldr: integer;
+  i, max, indx: integer;
+  min, fldr: Int64;
   pFD : FolderData;
 begin
-    max:=Ini.ReadInteger('Interface', 'MaxFoldersHistory',  50);
-    if max < 10 then
-      max:=10;
+    max:=NormalizeFolderHistoryLimit(
+      Ini.ReadInteger('Interface', 'MaxFoldersHistory', 50));
     Ini.WriteInteger    ('Interface', 'MaxFoldersHistory', max);
 
     try
     while (CB.Items.Count+maxdel) > max do begin
-      min := 9999999;
+      min:=0;
       indx:=-1;
       for i:=0 to CB.Items.Count - 1 do begin
         pFD := CB.Items.Objects[i] as FolderData;
@@ -7902,7 +7909,8 @@ begin
         if Today > pFD.Lst then
           fldr := 0- fldr;
 
-        fldr := fldr + pFD.Hit;
+        pFD.Hit:=NormalizeFolderHistoryHit(pFD.Hit);
+        fldr:=fldr + pFD.Hit;
         if (indx < 0) or (fldr < min) then begin
           min := fldr;
           indx:= i;

--- a/main.pas
+++ b/main.pas
@@ -7747,7 +7747,7 @@ var
   dd, mm, yy : string;
   nd, nm, ny : integer;
 begin
-  CB.Items.Clear;
+  ClearFolderHistoryItems(CB.Items);
 
   IniSec   := 'AddTorrent.' + FCurConn;
   j        := NormalizeFolderHistoryCount(
@@ -7918,7 +7918,7 @@ begin
       end;
 
       if indx > -1 then
-        CB.Items.Delete(indx)
+        FreeFolderHistoryItem(CB.Items, indx)
       else
         break;
     end;

--- a/movetorrent.pas
+++ b/movetorrent.pas
@@ -58,14 +58,21 @@ type
   private
     { private declarations }
   public
+    destructor Destroy; override;
     { public declarations }
   end;
 
 implementation
 
-uses main;
+uses main, FolderHistory;
 
 { TMoveTorrentForm }
+
+destructor TMoveTorrentForm.Destroy;
+begin
+  ClearFolderHistoryItems(edTorrentDir.Items);
+  inherited Destroy;
+end;
 
 procedure TMoveTorrentForm.btOKClick(Sender: TObject);
 begin


### PR DESCRIPTION
### Motivation

`TStrings` does not consistently own objects stored in `Items.Objects`. `FolderData` instances attached to add- and move-dialog history entries were removed with `Delete`, discarded with `Clear`, or left behind when a form was destroyed without being freed.

Repeated dialog use and history pruning therefore leaked folder metadata objects.

### Description

- Add ownership-aware helpers to the dedicated `FolderHistory` unit.
- Clear object slots before list removal so owning and non-owning `TStrings` implementations are both safe.
- Detach all attached objects, call `Clear` once, then free the detached objects.
- Use the ownership-aware removal helper when pruning and manually deleting entries.
- Free existing metadata before refilling a history list.
- Clear folder history metadata when add and move dialogs are destroyed.

### Scope

This PR only defines and applies `FolderData` ownership. It does not change history limits, scoring, or persistence behavior.

### Dependency

- Stacked on #1588 so this review contains only the ownership changes.
- Retarget to `master` after #1588 is merged.

### Testing

- `git diff --check`
- Guarded source rewrite checks verified the exact changed-file set.
- Cross-platform GitHub Actions CI passed for the complete stack against `master`.