### PR TITLE
Publish Windows artifacts for tagged releases

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   push:
     branches: [master]
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:
@@ -12,7 +14,7 @@ permissions:
 
 concurrency:
   group: windows-ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   windows-build:
@@ -107,3 +109,59 @@ jobs:
             Release/transgui-*.zip
             Release/transgui-*-setup*.exe
           if-no-files-found: error
+
+  publish-release:
+    name: Release / Windows assets
+    runs-on: ubuntu-latest
+    needs: windows-build
+    if: startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Set program version
+        run: |
+          set -euo pipefail
+          echo "PROG_VER=$(head -n 1 VERSION.txt)" >> "$GITHUB_ENV"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: artifacts
+
+      - name: Publish Windows release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          files=(
+            "artifacts/transgui-windows-x86/transgui-${PROG_VER}-i386-win32.zip"
+            "artifacts/transgui-windows-x86/transgui-${PROG_VER}-setup.exe"
+            "artifacts/transgui-windows-x86_64/transgui-${PROG_VER}-x86_64-win64.zip"
+            "artifacts/transgui-windows-x86_64/transgui-${PROG_VER}-setup_64bit.exe"
+          )
+
+          for file in "${files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "Missing release asset: $file" >&2
+              find artifacts -maxdepth 3 -type f -print >&2
+              exit 1
+            fi
+          done
+
+          for attempt in $(seq 1 60); do
+            if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+              gh release upload "$GITHUB_REF_NAME" "${files[@]}" --clobber
+              exit 0
+            fi
+            echo "Waiting for the main release workflow to create $GITHUB_REF_NAME ($attempt/60)..."
+            sleep 30
+          done
+
+          echo "GitHub Release $GITHUB_REF_NAME was not created within 30 minutes." >&2
+          exit 1


### PR DESCRIPTION
## Summary

- run the existing Windows CI workflow for tags
- keep tag runs non-cancelable so release artifacts are not interrupted
- prepare automatic publication of the x86 and x86_64 Windows release assets

## Why

Windows builds are already covered by CI, but tagged releases currently publish only the Linux and macOS artifacts collected by the main CI workflow. The Windows installers and ZIPs therefore still require a separate manual release step.

This PR keeps Windows packaging in `windows-ci.yml` and avoids changing the shared `ci.yml` release workflow. The release job waits for both Windows matrix builds, validates the expected artifacts, waits for the main CI workflow to create the tag's GitHub Release, and then uploads the Windows assets.

## Expected release assets

- `transgui-${PROG_VER}-i386-win32.zip`
- `transgui-${PROG_VER}-setup.exe`
- `transgui-${PROG_VER}-x86_64-win64.zip`
- `transgui-${PROG_VER}-setup_64bit.exe`

## Signing blocker

The existing `build-windows.ps1` path deliberately produces and validates **unsigned** CI artifacts, while the repository's release packaging supports Authenticode signing through `CODECERT`. Publishing these CI installers as official release assets would therefore weaken the existing release behavior, and `--clobber` could replace a manually published signed installer with an unsigned one on reruns.

The automatic upload path must not be merged as-is. The remaining design choice is to either add an approved signing-enabled tag build with protected certificate secrets, or keep signed installer publication manual and limit automation to artifacts that are intentionally unsigned.

## Already addressed review feedback

- tag runs no longer share the main release workflow's concurrency lock, avoiding a cross-workflow deadlock while waiting for release creation
- write-capable release steps pin `actions/checkout` and `actions/download-artifact` to immutable commit SHAs

## Scope

This PR does not change version naming or the winget manifest. Winget can be updated after the next signed Windows installer is published.