### PR TITLE
Reset the correct OpenSSL handle during cleanup

### DIFF
--- a/synapse/source/lib/ssl_openssl_lib.pas
+++ b/synapse/source/lib/ssl_openssl_lib.pas
@@ -2128,7 +2128,7 @@ begin
 {$IFNDEF CIL}
       FreeLibrary(SSLUtilHandle);
 {$ENDIF}
-      SSLLibHandle := 0;
+      SSLUtilHandle := 0;
     end;
 
 {$IFNDEF CIL}


### PR DESCRIPTION
## Summary

- clear `SSLUtilHandle` after unloading the OpenSSL utility library
- prevent repeated cleanup from attempting to unload a stale handle

## Validation

- `lazbuild -B transgui.lpi`
- targeted OpenSSL init, cleanup, repeated cleanup, reload, and final cleanup probe
- CRLF-aware `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the correct OpenSSL utility-library handle during cleanup to make repeated cleanup safe. Previously, after unloading `SSLUtilHandle`, the code cleared `SSLLibHandle`, leaving `SSLUtilHandle` pointing to an unloaded module; now it clears `SSLUtilHandle`.

- One-line fix in `synapse/source/lib/ssl_openssl_lib.pas`: set `SSLUtilHandle := 0` after `FreeLibrary(SSLUtilHandle)` (non-CIL path).
- Prevents double-unload and potential access violations during repeated cleanup; no change to normal init/cleanup and no migration required.

<sup>Written for commit 5427ca5a83fa5e9b8c1b6861c5defccb0806a47c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/transmission-remote-gui/transgui/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

