### PR TITLE
Verify macOS dependency package signatures before installation

### DIFF
--- a/setup/macosx/install_deps.sh
+++ b/setup/macosx/install_deps.sh
@@ -11,15 +11,28 @@ if [ -n "${sourceforge_mirror-}" ]; then
   mirror_string="&use_mirror=${sourceforge_mirror}"
 fi
 
+download_and_verify_pkg() {
+  url="$1"
+  pkg="$2"
+
+  wget "$url" -O "$pkg"
+
+  if ! pkgutil --check-signature "$pkg"; then
+    echo "Package signature verification failed for $pkg" >&2
+    rm -f "$pkg"
+    exit 1
+  fi
+}
+
 if [ ! -x "$(command -v fpc 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$fpc.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "fpc.pkg"
+  download_and_verify_pkg "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$fpc.pkg?r=&ts=$(date +%s)${mirror_string-}" "fpc.pkg"
   sudo ln -s /usr/local/lib/fpc/3.0.4/ppcx64 /usr/local/bin/ppcx64
   sudo installer -pkg "fpc.pkg" -target /
   rm "fpc.pkg"
 fi
 
 if [ ! -x "$(command -v lazbuild 2>&1)" ]; then
-  wget "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$lazarus.pkg?r=&ts=$(date +%s)${mirror_string-}" -O "lazarus.pkg"
+  download_and_verify_pkg "https://downloads.sourceforge.net/project/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20${lazarus_ver}/$lazarus.pkg?r=&ts=$(date +%s)${mirror_string-}" "lazarus.pkg"
   sudo installer -pkg "lazarus.pkg" -target /
   rm "lazarus.pkg"
 fi


### PR DESCRIPTION
### Motivation

The macOS dependency setup script previously downloaded the FPC and Lazarus installer packages with `wget` and then installed them with `sudo installer`, without verifying a checksum or digital signature.

If a downloaded package were replaced or tampered with, a malicious installer could therefore be executed with root privileges and potentially compromise the release artifacts. This change verifies package signatures before any privileged installation step to reduce that supply-chain risk.

### Changes

- Add a `download_and_verify_pkg` helper to `setup/macosx/install_deps.sh` to download `.pkg` files and verify them with `pkgutil --check-signature`.
- Require both FPC and Lazarus packages to pass signature verification before they are passed to `sudo installer`.
- Remove the downloaded package and abort immediately if signature verification fails, without running any `sudo` installation command.
- Keep the existing installation flow unchanged otherwise.

### Testing

- Ran shell syntax checks:
  ```sh
  sh -n setup/macosx/create_app_new.sh setup/macosx/install_deps.sh
  ```
  The checks passed.
- Used stubbed `wget`, `pkgutil`, and `sudo` commands to simulate successful signature verification and confirmed that the script continues through the existing installation flow and invokes `sudo installer`.
- Simulated a failing `pkgutil` verification and confirmed that the script aborts immediately without invoking any `sudo` command.

---

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57822a33608327bae946c36519d956)