### PR TITLE
Remove misleading RPC password warning

### DIFF
--- a/connoptions.pas
+++ b/connoptions.pas
@@ -591,7 +591,7 @@ procedure TConnOptionsForm.SaveConnSettings(const ConnName: string);
 var
   Sec: string;
   i: integer;
-  s,ss: string;
+  s: string;
 begin
   if ConnName = '' then
     exit;
@@ -628,11 +628,6 @@ begin
       WriteString(Sec, 'Password', '-')
     else
       if edPassword.Text <> '******' then begin
-        ss := edPassword.Text;
-        if (Pos('{', ss) > 0) or (Pos('}', ss) > 0) then begin
-          MessageDlg('The password can''t contain the characters: { }', mtError, [mbOK], 0);
-        end;
-
         if edPassword.Text = '' then
           s:=''
         else


### PR DESCRIPTION
### **User description**
## Summary

- Remove the brace warning from the stored RPC password field.
- Keep the existing password storage, mask, and ask-password behavior
  unchanged.

## Rationale

This field supplies the client's HTTP Basic credentials, not the daemon's
`rpc-password` setting. The warning applied the daemon's hashed-value
convention at the wrong layer and flagged valid client passwords.

The old dialog was non-blocking: after it closed, the same password was
still Base64-encoded and written to the client INI.

This cleanup was split from #1584 so that the connection-list validation
ordering fix can be reviewed independently.

## Testing

- `lazbuild -B transgui.lpi --lazarusdir=/usr/lib/lazarus/3.0`
- `make LAZARUS_DIR=/usr/lib/lazarus/3.0 all`
- `git diff --check origin/master...HEAD`
- Local multi-reviewer code review loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Passwords containing `{` or `}` can now be saved successfully.
  * Updated connection settings handling to encode changed passwords correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix


___

### **Description**
- Allow valid HTTP Basic passwords with braces

- Remove misleading daemon-password format warning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Password["Entered client password"]
  Storage["Base64-encoded connection setting"]
  Password -- "save without brace warning" --> Storage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connoptions.pas</strong><dd><code>Remove invalid brace restriction from password saving</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

connoptions.pas

<ul><li>Removes the validation warning that rejected <code>{</code> and <code>}</code> in passwords.<br> <li> Keeps existing Base64 encoding and password persistence behavior.<br> <li> Removes the now-unused temporary password variable.</ul>


</details>


  </td>
  <td><a href="https://github.com/transmission-remote-gui/transgui/pull/1597/files#diff-6eba056e2fa3a966f860694c05571bd7a2604eb9952cb470ef41720c6ee0b3e8">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

