### PR TITLE
Scale main-window icons for high-DPI displays

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -723,6 +723,8 @@ type
 {$endif LCLcarbon}
     FSlowResponse: TProgressImage;
     FDetailsWait: TProgressImage;
+    FNormalImages: TImageList;
+    FBigImages: TImageList;
     FDetailsWaitStart: TDateTime;
     FMainFormShown: boolean;
     FRestoreFilesFocus: boolean;
@@ -736,6 +738,10 @@ type
     FVSplitterDragging: boolean;
     FVSplitterDragHeight: integer;
     FVSplitterDragY: integer;
+
+    function CreateScaledImages(ASize: integer): TImageList;
+    procedure BuildScaledImages;
+    procedure ApplyIconLayout;
 
     procedure UpdateUI;
     procedure UpdateUIRpcVersion(RpcVersion: integer);
@@ -1572,6 +1578,174 @@ end;
 
 { TMainForm }
 
+function TMainForm.CreateScaledImages(ASize: integer): TImageList;
+var
+  Ico: TIcon;
+  IconCount, i: integer;
+  SourceImages: TImageList;
+begin
+  // Both source lists must keep the same semantic meaning at each shared index.
+  IconCount:=ImageList16.Count;
+  if ImageList32.Count > IconCount then
+    IconCount:=ImageList32.Count;
+  if IconCount = 0 then
+    raise Exception.Create('Main icon lists are empty.');
+  if ASize < 1 then
+    ASize:=1;
+
+  Result:=TImageList.Create(Self);
+  try
+    Result.Scaled:=False;
+    Result.Width:=ASize;
+    Result.Height:=ASize;
+    Ico:=TIcon.Create;
+    try
+      for i:=0 to IconCount - 1 do begin
+        if (ASize > ImageList16.Width) and (i < ImageList32.Count) then
+          SourceImages:=ImageList32
+        else if i < ImageList16.Count then
+          SourceImages:=ImageList16
+        else
+          SourceImages:=ImageList32;
+        SourceImages.GetIcon(i, Ico);
+        if Result.AddIcon(Ico) <> i then
+          raise Exception.CreateFmt('Unable to add scaled icon %d.', [i]);
+      end;
+    finally
+      Ico.Free;
+    end;
+  except
+    FreeAndNil(Result);
+    raise;
+  end;
+end;
+
+procedure TMainForm.BuildScaledImages;
+var
+  BigImages, NormalImages: TImageList;
+  BigSize, NormalSize: integer;
+begin
+  if (FNormalImages <> nil) or (FBigImages <> nil) then
+    exit;
+
+  NormalSize:=ScaleInt(ImageList16.Width);
+  BigSize:=ScaleInt(ImageList32.Width);
+  if (NormalSize = ImageList16.Width) and
+     (BigSize = ImageList32.Width) then begin
+    FNormalImages:=ImageList16;
+    FBigImages:=ImageList32;
+    exit;
+  end;
+
+  BigImages:=nil;
+  NormalImages:=nil;
+  try
+    try
+      NormalImages:=CreateScaledImages(NormalSize);
+      BigImages:=CreateScaledImages(BigSize);
+      FNormalImages:=NormalImages;
+      FBigImages:=BigImages;
+      NormalImages:=nil;
+      BigImages:=nil;
+    except
+      on E: Exception do begin
+        DebugLn('Failed to build scaled icon lists: ' + E.Message);
+        // Preserve the original fixed-size image lists if scaling fails.
+        FNormalImages:=nil;
+        FBigImages:=nil;
+      end;
+    end;
+  finally
+    NormalImages.Free;
+    BigImages.Free;
+  end;
+end;
+
+procedure TMainForm.ApplyIconLayout;
+var
+  C: TComponent;
+  i, ToolButtonSize: integer;
+  ToolbarImages: TImageList;
+begin
+  if FNormalImages <> nil then begin
+    // Keep all main-form controls using the shared icon lists on the same scaled set.
+    for i:=0 to ComponentCount - 1 do begin
+      C:=Components[i];
+      if C is TMenu then begin
+        if (TMenu(C).Images = ImageList16) or
+           (TMenu(C).Images = ImageList32) or
+           (TMenu(C).Images = FNormalImages) then begin
+          TMenu(C).Images:=FNormalImages;
+          TMenu(C).ImagesWidth:=FNormalImages.Width;
+        end;
+      end
+      else if C is TToolBar then begin
+        if (C <> MainToolBar) and
+           ((TToolBar(C).Images = ImageList16) or
+            (TToolBar(C).Images = ImageList32) or
+            (TToolBar(C).Images = FNormalImages) or
+            (TToolBar(C).Images = FBigImages)) then begin
+          TToolBar(C).Images:=FNormalImages;
+          TToolBar(C).ImagesWidth:=FNormalImages.Width;
+        end;
+      end
+      else if C is TCustomTabControl then begin
+        if (TCustomTabControl(C).Images = ImageList16) or
+           (TCustomTabControl(C).Images = ImageList32) or
+           (TCustomTabControl(C).Images = FNormalImages) then begin
+          TCustomTabControl(C).Images:=FNormalImages;
+          TCustomTabControl(C).ImagesWidth:=FNormalImages.Width;
+        end;
+      end
+      else if C is TVarGrid then begin
+        if (TVarGrid(C).Images = ImageList16) or
+           (TVarGrid(C).Images = ImageList32) or
+           (TVarGrid(C).Images = FNormalImages) then begin
+          TVarGrid(C).Images:=FNormalImages;
+        end;
+      end;
+    end;
+
+    FSlowResponse.Images:=FNormalImages;
+    FSlowResponse.Width:=ScaleInt(24);
+    FDetailsWait.Images:=FNormalImages;
+    FDetailsWait.Width:=FNormalImages.Width*2;
+    FDetailsWait.Height:=FDetailsWait.Width;
+    panDetailsWait.Width:=FDetailsWait.Width;
+    panDetailsWait.Height:=FDetailsWait.Height;
+  end;
+
+  if acBigToolbar.Checked then begin
+    if FBigImages <> nil then begin
+      ToolbarImages:=FBigImages;
+      ToolButtonSize:=Ini.ReadInteger('MainForm', 'BigToolBarHeight', 64);
+      if ToolButtonSize < ToolbarImages.Height + ScaleInt(8) then
+        ToolButtonSize:=ToolbarImages.Height + ScaleInt(8);
+    end
+    else begin
+      ToolbarImages:=ImageList32;
+      ToolButtonSize:=Ini.ReadInteger('MainForm', 'BigToolBarHeight', 64);
+    end;
+  end
+  else begin
+    if FNormalImages <> nil then begin
+      ToolbarImages:=FNormalImages;
+      ToolButtonSize:=ScaleInt(23);
+      if ToolButtonSize < ToolbarImages.Height + ScaleInt(7) then
+        ToolButtonSize:=ToolbarImages.Height + ScaleInt(7);
+    end
+    else begin
+      ToolbarImages:=ImageList16;
+      ToolButtonSize:=23;
+    end;
+  end;
+
+  MainToolBar.Images:=ToolbarImages;
+  MainToolBar.ImagesWidth:=ToolbarImages.Width;
+  MainToolBar.ButtonWidth:=ToolButtonSize;
+  MainToolBar.ButtonHeight:=ToolButtonSize;
+end;
+
 procedure TMainForm.FormCreate(Sender: TObject);
 var
   ws: TWindowState;
@@ -1764,8 +1938,8 @@ begin
     acMenuShow.Execute;
   if Ini.ReadBool('MainForm', 'Toolbar', acToolbarShow.Checked) <> acToolbarShow.Checked then
     acToolbarShow.Execute;
-  if Ini.ReadBool('MainForm', 'BigToolbar', acBigToolBar.Checked)  <> acBigToolBar.Checked then
-    acBigToolbar.Execute;
+  acBigToolbar.Checked:=Ini.ReadBool('MainForm', 'BigToolbar',
+    acBigToolbar.Checked);
 
   FFromNow := Ini.ReadBool('MainForm','FromNow',false);
   FWatchLocalFolder := Ini.ReadString('Interface','WatchLocalFolder','');
@@ -1885,6 +2059,9 @@ begin
     {$endif darwin}
     Ini.WriteInteger('Interface','FileOpenDoc',FLinuxOpenDoc);
   {$endif windows}
+
+  BuildScaledImages;
+  ApplyIconLayout;
 
 //Dynamic Associations of ShortCuts to Actions/Menus
   SL := TStringList.Create;
@@ -2399,15 +2576,7 @@ end;
 procedure TMainForm.acBigToolbarExecute(Sender: TObject);
 begin
   acBigToolbar.Checked:=not acBigToolbar.Checked;
-  if acBigToolbar.Checked then begin
-    MainToolBar.ButtonWidth:= Ini.ReadInteger('MainForm','BigToolBarHeight',64);
-    MainToolBar.ButtonHeight:= MainToolBar.ButtonWidth;
-    MainToolBar.Images:= ImageList32;
-  end else begin
-    MainToolBar.ButtonWidth:= 23;
-    MainToolBar.ButtonHeight:=23;
-    MainToolBar.Images:= ImageList16;
-    end;
+  ApplyIconLayout;
   Ini.WriteBool('MainForm', 'BigToolbar', acBigToolbar.Checked);
 end;
 

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -105,7 +105,9 @@ type
     function GetRowVisible(RowIndex: integer): boolean;
     function GetSortOrder: TSortOrder;
     procedure ItemsChanged(Sender: TObject);
+    procedure SetImages(const AValue: TImageList);
     procedure SetHideSelection(const AValue: boolean);
+    procedure UpdateDefaultRowHeight;
     procedure SetRow(const AValue: integer);
     procedure SetRowSelected(RowIndex: integer; const AValue: boolean);
     procedure SetRowVisible(RowIndex: integer; const AValue: boolean);
@@ -121,6 +123,7 @@ type
     procedure DoSearchTimer(Sender: TObject);
 
   protected
+    procedure CreateWnd; override;
     procedure SizeChanged(OldColCount, OldRowCount: Integer); override;
     procedure DrawCell(aCol,aRow: Integer; aRect: TRect; aState:TGridDrawState); override;
     procedure ColRowMoved(IsColumn: Boolean; FromIndex,ToIndex: Integer); override;
@@ -230,7 +233,7 @@ type
     property OnGetEditText;
     property OnSetEditText;
 
-    property Images: TImageList read FImages write FImages;
+    property Images: TImageList read FImages write SetImages;
     property MultiSelect: boolean read FMultiSelect write FMultiSelect default False;
     property SortColumn: integer read FSortColumn write SetSortColumn default -1;
     property SortOrder: TSortOrder read GetSortOrder write SetSortOrder default soAscending;
@@ -337,6 +340,41 @@ begin
       MouseMove([], pt.x, pt.y);
   finally
     FItemsChanging:=False;
+  end;
+end;
+
+procedure TVarGrid.SetImages(const AValue: TImageList);
+begin
+  if FImages=AValue then exit;
+  FImages:=AValue;
+  if not (csLoading in ComponentState) then
+    VisualChange;
+end;
+
+procedure TVarGrid.UpdateDefaultRowHeight;
+var
+  HiddenRows: array of boolean;
+  i, RowHeight: integer;
+begin
+  if not HandleAllocated then exit;
+
+  RowHeight:=Canvas.TextHeight('Xy') + 5;
+  if Assigned(FImages) then
+    RowHeight:=Max(RowHeight, FImages.Height + 4);
+  if DefaultRowHeight = RowHeight then exit;
+
+  // Changing DefaultRowHeight resets per-row heights, so retain hidden rows.
+  SetLength(HiddenRows, RowCount);
+  for i:=FixedRows to RowCount - 1 do
+    HiddenRows[i]:=RowHeights[i] = 0;
+  inherited BeginUpdate;
+  try
+    DefaultRowHeight:=RowHeight;
+    for i:=FixedRows to RowCount - 1 do
+      if HiddenRows[i] then
+        RowHeights[i]:=0;
+  finally
+    inherited EndUpdate;
   end;
 end;
 
@@ -573,6 +611,12 @@ procedure TVarGrid.DoSearchTimer(Sender: TObject);
 begin
   FSearchTimer.Enabled:=False;
   FCurSearch:='';
+end;
+
+procedure TVarGrid.CreateWnd;
+begin
+  inherited CreateWnd;
+  UpdateDefaultRowHeight;
 end;
 
 procedure TVarGrid.SizeChanged(OldColCount, OldRowCount: Integer);
@@ -992,8 +1036,7 @@ end;
 procedure TVarGrid.VisualChange;
 begin
   inherited VisualChange;
-  if HandleAllocated then
-    DefaultRowHeight:=Canvas.TextHeight('Xy') + 5;
+  UpdateDefaultRowHeight;
   UpdateColumnsMap;
 end;
 


### PR DESCRIPTION
## Summary

- scale the existing main-window icon assets with the application's interface scaling factor
- prefer the existing 32 px artwork when larger icons are needed
- preserve alpha/mask transparency while creating scaled icon lists
- apply the scaled icons consistently to toolbars, menus, tabs, grids, and progress indicators
- make `TVarGrid` keep its row height large enough for its assigned images across later visual changes and delayed handle creation
- preserve hidden grid rows when the default row height is recalculated
- preserve the existing Big Toolbar preference while ensuring its icons and buttons have enough room at higher scaling levels

Fixes #1177.

## Scope

This intentionally stays within the existing Lazarus/LCL architecture. It does not change the Windows DPI-awareness manifest, add Per-Monitor V2 handling, introduce SVG or third-party icon assets, upgrade Lazarus/FPC, or change torrent/RPC behavior.

Windows builds already embed `<dpiAware>True</dpiAware>`, so they run as System DPI Aware and receive the system DPI during initialization. Per-monitor DPI changes remain outside this PR.

`TVarGrid` remains DPI-agnostic: it only derives its minimum row height from the actual `Images.Height` it is given.

The change is limited to `main.pas` and `vargrid.pas`.

## Reviewer follow-up

- rebased directly onto current `master` (`8f618dc`)
- moved image-aware row-height maintenance into `TVarGrid` instead of setting it once from `TMainForm`
- added an `Images` setter so runtime image-list changes recalculate the grid layout
- call the shared row-height calculation from both `VisualChange` and `CreateWnd`, so grids whose handles are created later receive the same invariant
- preserve rows hidden with `RowHeights[x] = 0` while changing `DefaultRowHeight`
- batch the default-row-height change and hidden-row restoration with the inherited grid update lock, avoiding repeated layout work without entering `Items.BeginUpdate`
- log scaled-image-list construction failures with the existing `DebugLn` mechanism while retaining the graceful fallback
- document the semantic-index invariant between the 16 px and 32 px source image lists
- document that the component scan intentionally updates main-form controls using the shared icon lists

## Validation

- final branch is one commit ahead of current `master` and zero commits behind
- final diff contains only `main.pas` and `vargrid.pas`
- Windows x86 and x86_64 builds pass with the CI-pinned Lazarus 2.2.6
- Linux x86_64 build and GTK2 startup smoke test pass
- Linux i686 build passes
- macOS DMG build passes
- zip tarball smoke test and all static checks pass
- uses `GetIcon`/`AddIcon` so scaled images retain icon transparency and masks
- preserves Windows user-menu icons by building the scaled lists after those dynamic icons are loaded
- unrelated image lists such as country flags are left untouched