### PR TITLE
Stop queued IP lookups during resolver shutdown

### DIFF
--- a/ipresolver.pas
+++ b/ipresolver.pas
@@ -91,7 +91,7 @@ begin
           FLock.Enter;
           try
             ip:='';
-            if FResolveIp.Count > 0 then begin
+            if not Terminated and (FResolveIp.Count > 0) then begin
               ip:=FResolveIp[0];
               FResolveIp.Delete(0);
             end;
@@ -173,9 +173,16 @@ destructor TIpResolver.Destroy;
 var
   i: integer;
 begin
-  Terminate;
-  if not Suspended then
+  FLock.Enter;
+  try
+    Terminate;
+  finally
+    FLock.Leave;
+  end;
+  if not Suspended then begin
+    FResolveEvent.SetEvent;
     WaitFor;
+  end;
   FResolveIp.Free;
   FResolveEvent.Free;
   FLock.Free;


### PR DESCRIPTION
## Motivation

The peer IP resolver used to keep draining queued reverse-DNS work after shutdown began. Because `ResolveIPToName` is synchronous, destruction could be delayed by lookups that had not started when shutdown was requested.

## Changes

- coordinate termination and queue dequeueing with the same `FLock` critical section
- do not claim another queued IP after termination has been established
- signal `FResolveEvent` during destruction so an idle worker wakes immediately instead of waiting for the 200 ms timeout
- preserve completion of a DNS lookup that was already claimed before shutdown

An already-running synchronous `ResolveIPToName` call remains non-cancellable.

## Validation

- rebased directly onto current `master` (`e47d82b`)
- single focused commit; diff is limited to `ipresolver.pas`
- source review confirms shutdown and queue claiming now have a defined ordering through `FLock`
- latest revision passes the repository CI: Windows x86/x86_64, macOS, Linux x86_64/i686/armv6l/armv7l, zip smoke, and static checks

## Testing note

A deterministic regression test for the shutdown/dequeue race would be useful. The repository currently has no automated Pascal unit-test suite around `TIpResolver` or an injectable DNS resolver. Introducing a resolver abstraction and concurrency-test infrastructure solely for this small fix would materially expand its scope, so this PR keeps the production change minimal and relies on the repository's cross-platform build/smoke CI. A dedicated resolver-test harness can be added separately without coupling it to this bug fix.