### PR TITLE
Avoid leaking an unused magnet response array

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -5011,7 +5011,6 @@ begin
       CheckStatus(False);
       exit;
     end;
-    t:=TJSONArray.Create;
     t:=args.Arrays['torrents'];
     for i:= 0 to t.Count-1 do
       begin


### PR DESCRIPTION
## Motivation

`TMainForm.MenuItem101Click` allocated an empty `TJSONArray` and immediately overwrote the variable with `args.Arrays['torrents']`. The newly allocated array therefore became unreachable and leaked on every successful Copy Magnet Link(s) request.

## Change

Remove the redundant allocation and keep `t` pointing directly at the `torrents` array owned by `args`. `args.Free` continues to release that response array, so no separate free is needed.

The branch history has been cleaned up so the PR is now a single focused commit whose diff is exactly this one-line deletion.

## Validation

- rebased directly onto current `master` (`e47d82b`)
- one commit and one changed file
- final diff is exactly one deleted line in `main.pas`
- no behavior change for empty, single, or multi-selection paths
- latest revision passes the repository CI: Windows x86/x86_64, macOS, Linux x86_64/i686/armv6l/armv7l, zip smoke, and static checks

## Attribution

The cleanup that removed the unrelated formatting hunk was contributed through a Pullfrog review suggestion. The squashed commit preserves that contribution with the original `Co-authored-by: pullfrog[bot] <226033991+pullfrog[bot]@users.noreply.github.com>` trailer.